### PR TITLE
Spring4shell measures

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest, macOS-latest, windows-latest]
-        jdk: [ 8, 11 ]  # (open)JDK releases
+        jdk: [ 11, 17 ]  # (open)JDK releases
 
     steps:
     - uses: actions/checkout@v2

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,8 @@
 plugins {
     // Spring boot & dependency management:
     // https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/htmlsingle/
-    id 'org.springframework.boot' version '2.5.7'
+    id 'org.springframework.boot' version '2.5.12'
+    // https://docs.spring.io/dependency-management-plugin/docs/current-SNAPSHOT/reference/html/
     id "io.spring.dependency-management" version "1.0.11.RELEASE"
     // Lombok generates getter and setter and more. https://projectlombok.org/
     // check for new versions here: https://plugins.gradle.org/plugin/io.freefair.lombok
@@ -13,6 +14,10 @@ plugins {
     //id "com.github.kt3k.coveralls" version "2.12.0" 
     id "org.owasp.dependencycheck" version "6.5.0.1"
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
+}
+
+ext {
+    jdkVersion = 17
 }
 
 lombok {
@@ -108,9 +113,6 @@ jar {
 }
 
 compileJava {
-    // specify java version for compiling
-    // https://docs.gradle.org/current/userguide/building_java_projects.html#sec:java_cross_compilation
-    options.release = 11
     // Display more warnings when compiling.
     options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
 }
@@ -121,7 +123,7 @@ java {
         // Gradle itself and building JVM projects." So let's make sure
         // we use the right thing here.
         // https://docs.gradle.org/current/userguide/toolchains.html#toolchains
-        languageVersion = JavaLanguageVersion.of(11)
+        languageVersion = JavaLanguageVersion.of(jdkVersion)
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,10 +16,6 @@ plugins {
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
-ext {
-    jdkVersion = 17
-}
-
 lombok {
     // check here for new versions: https://projectlombok.org/download
     version = '1.18.22'
@@ -34,6 +30,10 @@ archivesBaseName = 'TypedPIDMaker'
 description = "A gateway to manage PIDs containing profiles and typed attributes."
 version = '0.4'
 group = 'edu.kit.datamanager'
+
+println "Running gradle version: $gradle.gradleVersion"
+println "Building ${name} version: ${version}"
+println "JDK version: ${JavaVersion.current()}"
 
 repositories {
     mavenLocal()
@@ -120,10 +120,11 @@ compileJava {
 java {
     toolchain {
         // "By default, Gradle uses the same Java version for running
-        // Gradle itself and building JVM projects." So let's make sure
-        // we use the right thing here.
+        // Gradle itself and building JVM projects."
+        // We can enforce a specific version here. By defult, we do not do this
+        // to enable the CI to test with different JDKs.
         // https://docs.gradle.org/current/userguide/toolchains.html#toolchains
-        languageVersion = JavaLanguageVersion.of(jdkVersion)
+        //languageVersion = JavaLanguageVersion.of(jdkVersion)
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     // Spring boot & dependency management:
     // https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/htmlsingle/
-    id 'org.springframework.boot' version '2.5.12'
+    id 'org.springframework.boot' version '2.5.13'
     // https://docs.spring.io/dependency-management-plugin/docs/current-SNAPSHOT/reference/html/
     id "io.spring.dependency-management" version "1.0.11.RELEASE"
     // Lombok generates getter and setter and more. https://projectlombok.org/


### PR DESCRIPTION
- updates Spring to non-vulnerable versions
- uses now Java 17, CI set to JDK 11 and 17 for testing and compiling.