### PR TITLE
Use other JRE docker images.

### DIFF
--- a/docker/Dockerfile-build-in-image
+++ b/docker/Dockerfile-build-in-image
@@ -6,7 +6,7 @@ ARG SERVICE_DIRECTORY=/typid
 ####################################################
 
 
-FROM openjdk:17-bullseye AS build-typid
+FROM eclipse-temurin:17 AS build-typid
 LABEL maintainer="webmaster@datamanager.kit.edu"
 LABEL stage=build
 RUN mkdir -p ${SERVICE_DIRECTORY}/
@@ -17,7 +17,7 @@ RUN ./gradlew build --stacktrace && \
 
 
 # Create a clean, minimal image
-FROM openjdk:17-bullseye as typed-pid-maker
+FROM eclipse-temurin:17 as typed-pid-maker
 LABEL maintainer="webmaster@datamanager.kit.edu"
 LABEL stage=run
 

--- a/docker/Dockerfile-reuse-local-build
+++ b/docker/Dockerfile-reuse-local-build
@@ -6,7 +6,7 @@ ARG SERVICE_DIRECTORY=/typid
 ####################################################
 
 # Create a clean, minimal image
-FROM openjdk:17-bullseye as typed-pid-maker
+FROM eclipse-temurin:17 as typed-pid-maker
 LABEL maintainer="webmaster@datamanager.kit.edu"
 LABEL stage=run
 


### PR DESCRIPTION
The old ones are deprecated (see https://hub.docker.com/_/openjdk/). This one has [several architectures available](https://hub.docker.com/layers/library/eclipse-temurin/17-jdk/images/sha256-24634c901f1f6c915ad2e962ee2471fc08d5a7a329383a7991148cdb78b46fef?context=explore).

See also: https://github.com/kit-data-manager/FAIR-DO-Lab/issues/1