### PR TITLE
Fix the guava dependency not being found.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation("edu.kit.datamanager:service-base:1.0.4")
     implementation("edu.kit.datamanager:repo-core:1.0.3")
     // com.google.common, LoadingCache
-    implementation "com.github.google.guava:guava:v31.1"
+    implementation("com.google.guava:guava:31.1-jre")
     // Required by Spring/Javers at runtime
     implementation 'com.google.code.gson:gson:2.9.1'
 


### PR DESCRIPTION
Something must have changed regarding the publishing of guava. I re-added the dependency according to the official instructions. This now uses maven central instead of jitpack.