### PR TITLE
Add tabulator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,17 @@
 
 ![License](https://img.shields.io/github/license/kit-data-manager/pit-service.svg) [![Java CI with Gradle](https://github.com/kit-data-manager/pit-service/actions/workflows/gradle.yml/badge.svg)](https://github.com/kit-data-manager/pit-service/actions/workflows/gradle.yml)
 
-This project provides a service for dealing with PID Information Types and Kernel Information Profiles according to the recommendations of the Research Data Alliance. In the RDA context, this kind of service is called a "PIT service".
-Depending on the configuration it allows minting PIDs from different services, to lookup PIDs with a specific record entry and to validate PIDs according to profile information
-contained in the PID record.
+The Typed PID Maker enables the creation, maintenance, and validation of PIDs. It ensures the PID contains typed, machine-actionable information using validation. This is especially helpful in the context of FAIR Digital Objects (FAIR DOs / FDOs). To make this work, our validation strategy requires a reference to a registered Kernel Information Profile within the PID record, as defined by the [recommendations of the Research Data Alliance (RDA)](https://doi.org/10.15497/rda00031). [In the RDA context, this kind of service is called a "PIT service"](https://doi.org/10.15497/FDAA09D5-5ED0-403D-B97A-2675E1EBE786). We use Handle PIDs, which can be created using a Handle Prefix (not included). For testing or other local purposes, we support sandboxed PIDs, which require no external service.
+
+## Features
+
+- ✅ Create PIDs containing typed key-value-pairs for easy, fast, and automated decision-making.
+- ✅ Maintain the information within these PIDs.
+- ✅ Validate PIDs.
+- ✅ Resolve PIDs.
+- ✅ Store the created PIDs in your database.
+  - ✅ Pagination support
+  - ✅ Tabulator.js support
 
 ## How to build
 
@@ -18,7 +26,7 @@ After obtaining the sources change to the folder where the sources are located p
 user@localhost:/home/user/typed-pid-maker$ ./gradlew build
 > Configure project :
 Using release profile for building notification-service
-<-------------> 0% EXECUTING [0s]
+<-------------> 42% EXECUTING [0s]
 [...]
 user@localhost:/home/user/typed-pid-maker$
 ```

--- a/src/main/java/edu/kit/datamanager/pit/web/ITypingRestResource.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/ITypingRestResource.java
@@ -286,13 +286,13 @@ public interface ITypingRestResource {
      * @return the PIDs matching all given contraints.
      */
     @Operation(
-        summary = "Returns all known PIDs.",
-        description = "Returns all known PIDs, limited by the given page size and number."
+        summary = "Returns all known PIDs. Supports paging, filtering criteria, and different formats.",
+        description = "Returns all known PIDs, limited by the given page size and number. "
             + "Several filtering criteria are also available. Known PIDs are defined as "
             + "being stored in a local store. This store is not a cache! Instead, the "
             + "service remembers every PID which it created (and resolved, depending on "
-            + "the configuration parameter `pit.storage.strategy` of the service) on"
-            + "request.",
+            + "the configuration parameter `pit.storage.strategy` of the service) on "
+            + "request. Use the Accept header to adjust the format.",
         responses = {
             @ApiResponse(
                 responseCode = "200",
@@ -345,7 +345,13 @@ public interface ITypingRestResource {
      * @return the PIDs matching all given contraints.
      */
       @Operation(
-        summary = "Like findAll, but the return value is formatted for the tabulator javascript library.",
+        summary = "Returns all known PIDs. Supports paging, filtering criteria, and different formats.",
+        description = "Returns all known PIDs, limited by the given page size and number. "
+            + "Several filtering criteria are also available. Known PIDs are defined as "
+            + "being stored in a local store. This store is not a cache! Instead, the "
+            + "service remembers every PID which it created (and resolved, depending on "
+            + "the configuration parameter `pit.storage.strategy` of the service) on "
+            + "request. Use the Accept header to adjust the format.",
         responses = {
             @ApiResponse(
                 responseCode = "200",

--- a/src/main/java/edu/kit/datamanager/pit/web/TabulatorPaginationFormat.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/TabulatorPaginationFormat.java
@@ -1,0 +1,29 @@
+package edu.kit.datamanager.pit.web;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+/**
+ * JSON representation for pagination using the Tabulator.js library.
+ */
+public class TabulatorPaginationFormat<T> {
+
+    public TabulatorPaginationFormat(Page<T> page) {
+        this.lastPage = page.getTotalPages();
+        this.data = page.getContent();
+    }
+
+    @JsonProperty("last_page")
+    private int lastPage;
+
+    private List<T> data;
+
+    public int getLastPage() {
+        return lastPage;
+    }
+
+    public List<T> getData() {
+        return data;
+    }
+}

--- a/src/main/java/edu/kit/datamanager/pit/web/impl/TypingRESTResourceImpl.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/impl/TypingRESTResourceImpl.java
@@ -30,6 +30,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.http.client.cache.HeaderConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -658,6 +659,12 @@ public class TypingRESTResourceImpl implements ITypingRestResource {
             UriComponentsBuilder uriBuilder) throws IOException
     {
         Page<KnownPid> page = this.findAllPage(createdAfter, createdBefore, modifiedAfter, modifiedBefore, pageable);
+        response.addHeader(
+            HeaderConstants.CONTENT_RANGE,
+            ControllerUtils.getContentRangeHeader(
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements()));
         return ResponseEntity.ok().body(page.getContent());
     }
 
@@ -673,6 +680,12 @@ public class TypingRESTResourceImpl implements ITypingRestResource {
             UriComponentsBuilder uriBuilder) throws IOException
     {
         Page<KnownPid> page = this.findAllPage(createdAfter, createdBefore, modifiedAfter, modifiedBefore, pageable);
+        response.addHeader(
+            HeaderConstants.CONTENT_RANGE,
+            ControllerUtils.getContentRangeHeader(
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements()));
         TabulatorPaginationFormat<KnownPid> tabPage = new TabulatorPaginationFormat<>(page);
         return ResponseEntity.ok().body(tabPage);
     }

--- a/src/test/java/edu/kit/datamanager/pit/web/RestWithInMemoryTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/RestWithInMemoryTest.java
@@ -53,7 +53,6 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -411,7 +410,7 @@ public class RestWithInMemoryTest {
         Instant modifiedBefore,
         Optional<Pageable> pageable
     ) throws IOException {
-        ResponseEntity<Collection<KnownPid>> response = this.restImpl.findByInterval(
+        ResponseEntity<List<KnownPid>> response = this.restImpl.findAll(
             createdAfter,
             createdBefore,
             modifiedAfter,
@@ -421,8 +420,7 @@ public class RestWithInMemoryTest {
             null,
             null
         );
-        Collection<KnownPid> pidinfos = response.getBody();
-        return new ArrayList<>(pidinfos);
+        return new ArrayList<>(response.getBody());
     }
 
     /**

--- a/src/test/java/edu/kit/datamanager/pit/web/RestWithInMemoryTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/RestWithInMemoryTest.java
@@ -137,7 +137,41 @@ public class RestWithInMemoryTest {
         // we store PIDs only if the PID was created successfully
         assertEquals(0, this.knownPidsDao.count());
 
-        // Nothing is registered, our local storags contains no PIDs
+    @Test
+    public void testNontypeRecord() throws Exception {
+        PIDRecord r = new PIDRecord();
+        r.addEntry("unregisteredType", "for Testing", "hello");
+        this.mockMvc
+            .perform(
+                post("/api/v1/pit/pid/")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(new ObjectMapper().writeValueAsString(r))
+                    .accept(MediaType.ALL)
+            )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(MockMvcResultMatchers.status().isConflict());
+        
+        // we store PIDs only if the PID was created successfully
+        assertEquals(0, this.knownPidsDao.count());
+    }
+
+    @Test
+    public void testInvalidRecordWithProfile() throws Exception {
+        PIDRecord r = new PIDRecord();
+        r.addEntry("21.T11148/076759916209e5d62bd5", "for Testing", "21.T11148/301c6f04763a16f0f72a");
+        this.mockMvc
+            .perform(
+                post("/api/v1/pit/pid/")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(new ObjectMapper().writeValueAsString(r))
+                    .accept(MediaType.ALL)
+            )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(MockMvcResultMatchers.status().isConflict());
+        
+        // we store PIDs only if the PID was created successfully
         assertEquals(0, this.knownPidsDao.count());
     }
 

--- a/src/test/java/edu/kit/datamanager/pit/web/RestWithInMemoryTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/RestWithInMemoryTest.java
@@ -135,8 +135,10 @@ public class RestWithInMemoryTest {
             )
             .andDo(MockMvcResultHandlers.print())
             .andExpect(MockMvcResultMatchers.status().isConflict());
+        
         // we store PIDs only if the PID was created successfully
         assertEquals(0, this.knownPidsDao.count());
+    }
 
     @Test
     public void testNontypeRecord() throws Exception {
@@ -418,7 +420,7 @@ public class RestWithInMemoryTest {
 
     /**
      * Wrapper to query known PIDs via API given time intervals for the creation
-     * timestamp and modification timestamp. This is a reusable etst component.
+     * timestamp and modification timestamp. This is a reusable test component.
      * 
      * @param createdAfter   lower end for the creation timestamp interval
      * @param createdBefore  upper end for the creation timestamp interval

--- a/src/test/java/edu/kit/datamanager/pit/web/TabulatorPaginationFormatTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/TabulatorPaginationFormatTest.java
@@ -1,0 +1,23 @@
+package edu.kit.datamanager.pit.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
+public class TabulatorPaginationFormatTest {
+    @Test
+    void testConstructorAssignments() {
+        List<String> list = new ArrayList<>();
+        list.add("test1");
+        list.add("test2");
+        Page<String> page = new PageImpl<String>(list);
+        TabulatorPaginationFormat<String> f = new TabulatorPaginationFormat<>(page);
+        assertEquals(1, f.getLastPage());
+        assertEquals(list, f.getData());
+    }
+}

--- a/src/test/resources/test/application-test.properties
+++ b/src/test/resources/test/application-test.properties
@@ -200,6 +200,7 @@ pit.pidsystem.handle.baseURI = http://hdl.handle.net/
 pit.typeregistry.baseURI = http://dtr-test.pidconsortium.eu/
 #http://typeregistry.org/registrar
 pit.pidsystem.implementation = IN_MEMORY
+pit.validation.strategy:embedded-strict
 
 ####################################
 # Storing known PIDs in a database #


### PR DESCRIPTION
To support GUIs using tabulator.js, the Typed PID Maker now supports its specific format described here: https://tabulator.info/docs/5.4/page#remote-response

- [x] Return tabulator format when receiving a paging request with "Accept" header "application/tabulator+json"
- [x] Use "Content-Range" header in the response (not required by tabulator, but nice)
- [x] documented in swagger/openapi (http://localhost:8090/swagger-ui.html): There is an issue with the comments, fix it.
- [x] Mention it in the README somewhere