### PR TITLE
Persist sandboxed PIDs 2

### DIFF
--- a/src/main/java/edu/kit/datamanager/pit/Application.java
+++ b/src/main/java/edu/kit/datamanager/pit/Application.java
@@ -25,12 +25,14 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.cache.RemovalNotification;
 
 import edu.kit.datamanager.pit.configuration.ApplicationProperties;
+import edu.kit.datamanager.pit.domain.PIDRecord;
 import edu.kit.datamanager.pit.domain.TypeDefinition;
 import edu.kit.datamanager.pit.pidsystem.IIdentifierSystem;
 import edu.kit.datamanager.pit.pitservice.ITypingService;
 import edu.kit.datamanager.pit.pitservice.impl.TypingService;
 import edu.kit.datamanager.pit.typeregistry.ITypeRegistry;
 import edu.kit.datamanager.pit.typeregistry.impl.TypeRegistry;
+import edu.kit.datamanager.pit.web.converter.SimplePidRecordConverter;
 import edu.kit.datamanager.security.filter.KeycloakJwtProperties;
 
 import java.io.IOException;
@@ -55,6 +57,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.http.client.BufferingClientHttpRequestFactory;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.client.RestTemplate;
@@ -162,6 +165,11 @@ public class Application {
     // Reads keycloak related settings from properties.application.
     public KeycloakJwtProperties properties() {
       return new KeycloakJwtProperties();
+    }
+
+    @Bean
+    public HttpMessageConverter<PIDRecord> simplePidRecordConverter() {
+        return new SimplePidRecordConverter();
     }
 
     public static void main(String[] args) {

--- a/src/main/java/edu/kit/datamanager/pit/Application.java
+++ b/src/main/java/edu/kit/datamanager/pit/Application.java
@@ -94,7 +94,7 @@ public class Application {
     }
 
     @Bean(name = "OBJECT_MAPPER_BEAN")
-    public ObjectMapper jsonObjectMapper() {
+    public static ObjectMapper jsonObjectMapper() {
         return Jackson2ObjectMapperBuilder.json()
                 .serializationInclusion(JsonInclude.Include.NON_EMPTY) // Don’t include null values
                 .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS) // ISODate

--- a/src/main/java/edu/kit/datamanager/pit/domain/PIDRecord.java
+++ b/src/main/java/edu/kit/datamanager/pit/domain/PIDRecord.java
@@ -30,6 +30,13 @@ public class PIDRecord {
         this.entries = new HashMap<>();
     }
 
+    public PIDRecord(SimplePidRecord rec) {
+        this.entries = new HashMap<>();
+        for (SimplePair pair : rec.getPairs()) {
+            this.addEntry(pair.getKey(), "", pair.getValue());
+        }
+    }
+
     // Convenience setter / builder method.
     public PIDRecord withPID(String pid) {
         this.setPid(pid);

--- a/src/main/java/edu/kit/datamanager/pit/domain/SimplePair.java
+++ b/src/main/java/edu/kit/datamanager/pit/domain/SimplePair.java
@@ -1,0 +1,20 @@
+package edu.kit.datamanager.pit.domain;
+
+public class SimplePair {
+    private String key;
+
+    private String value;
+
+    SimplePair(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/edu/kit/datamanager/pit/domain/SimplePair.java
+++ b/src/main/java/edu/kit/datamanager/pit/domain/SimplePair.java
@@ -5,6 +5,11 @@ public class SimplePair {
 
     private String value;
 
+    /**
+     * Required for (de-)serialization.
+     */
+    SimplePair() {}
+
     SimplePair(String key, String value) {
         this.key = key;
         this.value = value;

--- a/src/main/java/edu/kit/datamanager/pit/domain/SimplePidRecord.java
+++ b/src/main/java/edu/kit/datamanager/pit/domain/SimplePidRecord.java
@@ -10,12 +10,17 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class SimplePidRecord {
 
     @JsonIgnore
-    public static final String CONTENT_TYPE = "application/vnd.datamanager.pid.simple";
+    public static final String CONTENT_TYPE = "application/vnd.datamanager.pid.simple+json";
 
     private String pid;
 
     @JsonProperty("record")
     private List<SimplePair> pairs;
+
+    /**
+     * Required for (de-)serialization.
+     */
+    public SimplePidRecord() {}
 
     /**
      * Converts a given PIDRecord representation into a SimplePidRecord

--- a/src/main/java/edu/kit/datamanager/pit/domain/SimplePidRecord.java
+++ b/src/main/java/edu/kit/datamanager/pit/domain/SimplePidRecord.java
@@ -21,7 +21,7 @@ public class SimplePidRecord {
      * Converts a given PIDRecord representation into a SimplePidRecord
      * representation.
      * 
-     * @param rec
+     * @param rec a given PID record to convert.
      */
     public SimplePidRecord(PIDRecord rec) {
         this.pid = rec.getPid();

--- a/src/main/java/edu/kit/datamanager/pit/domain/SimplePidRecord.java
+++ b/src/main/java/edu/kit/datamanager/pit/domain/SimplePidRecord.java
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class SimplePidRecord {
 
     @JsonIgnore
+    public static final String CONTENT_TYPE_PURE = "vnd.datamanager.pid.simple";
+    @JsonIgnore
     public static final String CONTENT_TYPE = "application/vnd.datamanager.pid.simple+json";
 
     private String pid;

--- a/src/main/java/edu/kit/datamanager/pit/domain/SimplePidRecord.java
+++ b/src/main/java/edu/kit/datamanager/pit/domain/SimplePidRecord.java
@@ -1,0 +1,53 @@
+package edu.kit.datamanager.pit.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map.Entry;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SimplePidRecord {
+
+    @JsonIgnore
+    public static final String CONTENT_TYPE = "application/vnd.datamanager.pid.simple";
+
+    private String pid;
+
+    @JsonProperty("record")
+    private List<SimplePair> pairs;
+
+    /**
+     * Converts a given PIDRecord representation into a SimplePidRecord
+     * representation.
+     * 
+     * @param rec
+     */
+    public SimplePidRecord(PIDRecord rec) {
+        this.pid = rec.getPid();
+        this.pairs = new ArrayList<>();
+        for (Entry<String, List<PIDRecordEntry>> entry : rec.getEntries().entrySet()) {
+            String key = entry.getKey();
+            for (PIDRecordEntry value : entry.getValue()) {
+                SimplePair p = new SimplePair(key, value.getValue());
+                this.pairs.add(p);
+            }
+        }
+    }
+
+    public List<SimplePair> getPairs() {
+        return pairs;
+    }
+
+    public void setPairs(List<SimplePair> pairs) {
+        this.pairs = pairs;
+    }
+
+    public String getPid() {
+        return pid;
+    }
+
+    public void setPid(String pid) {
+        this.pid = pid;
+    }
+}

--- a/src/main/java/edu/kit/datamanager/pit/pidsystem/impl/sandbox/PidDatabaseObject.java
+++ b/src/main/java/edu/kit/datamanager/pit/pidsystem/impl/sandbox/PidDatabaseObject.java
@@ -8,8 +8,6 @@ import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
-import org.springframework.transaction.annotation.Transactional;
-
 import edu.kit.datamanager.pit.domain.PIDRecord;
 import edu.kit.datamanager.pit.domain.PIDRecordEntry;
 import lombok.Data;
@@ -25,7 +23,6 @@ import lombok.EqualsAndHashCode;
 @Entity
 @Data
 @EqualsAndHashCode(callSuper = false)
-@Transactional
 public class PidDatabaseObject {
     
     @Id
@@ -39,7 +36,7 @@ public class PidDatabaseObject {
     private List<String> values = new ArrayList<>();
 
     /** For hibernate */
-    PidDatabaseObject() {}
+    public PidDatabaseObject() {}
 
     /** Protected constructor for testing purposes. */
     protected PidDatabaseObject(String pid, String hiddenIndentifier) {

--- a/src/main/java/edu/kit/datamanager/pit/pidsystem/impl/sandbox/PidDatabaseObject.java
+++ b/src/main/java/edu/kit/datamanager/pit/pidsystem/impl/sandbox/PidDatabaseObject.java
@@ -1,0 +1,67 @@
+package edu.kit.datamanager.pit.pidsystem.impl.sandbox;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import edu.kit.datamanager.pit.domain.PIDRecord;
+import edu.kit.datamanager.pit.domain.PIDRecordEntry;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * A very simple representation of a PID record to be stored in databases.
+ * 
+ * Similar to `KnownPid`, it can be stored in a database, but additionally
+ * stores all keys and values, similar to SimplePidRecord. The idea is to use
+ * this object for storage only and not have a complex mix of annotations.
+ */
+@Entity
+@Data
+@EqualsAndHashCode(callSuper = false)
+@Transactional
+public class PidDatabaseObject {
+    
+    @Id
+    @Column(name = "pid")
+    private String pid;
+    
+    @ElementCollection
+    private List<String> keys = new ArrayList<>();
+
+    @ElementCollection
+    private List<String> values = new ArrayList<>();
+
+    /** For hibernate */
+    PidDatabaseObject() {}
+
+    /** Protected constructor for testing purposes. */
+    protected PidDatabaseObject(String pid, String hiddenIndentifier) {
+        this.pid = pid;
+        PIDRecordEntry hidden = new PIDRecordEntry();
+        hidden.setKey(hiddenIndentifier);
+        hidden.setValue(hiddenIndentifier);
+        this.appendEntry(hidden);
+    }
+
+    public PidDatabaseObject(PIDRecord other) {
+        this.pid = other.getPid();
+        other
+            .getEntries()
+            .values()
+            .stream()
+            .flatMap(List<PIDRecordEntry>::stream)
+            .forEach(this::appendEntry);
+    }
+
+    public void appendEntry(PIDRecordEntry entry) {
+        this.keys.add(entry.getKey());
+        this.values.add(entry.getValue());
+    }
+}

--- a/src/main/java/edu/kit/datamanager/pit/pidsystem/impl/sandbox/PidDatabaseObjectDao.java
+++ b/src/main/java/edu/kit/datamanager/pit/pidsystem/impl/sandbox/PidDatabaseObjectDao.java
@@ -1,0 +1,10 @@
+package edu.kit.datamanager.pit.pidsystem.impl.sandbox;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface PidDatabaseObjectDao extends JpaRepository<PidDatabaseObject, String>, JpaSpecificationExecutor<PidDatabaseObject> {
+    Optional<PidDatabaseObject> findByPid(String pid);
+}

--- a/src/main/java/edu/kit/datamanager/pit/web/ITypingRestResource.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/ITypingRestResource.java
@@ -141,7 +141,7 @@ public interface ITypingRestResource {
      * profile. Before creating the record, the record information will be
      * validated against the profile.
      *
-     * @param record The PID record.
+     * @param rec The PID record.
      *
      * @return either 201 and a record representation, 409 on validation fail
      *         (conflict) or 500 on other server errors.

--- a/src/main/java/edu/kit/datamanager/pit/web/ITypingRestResource.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/ITypingRestResource.java
@@ -143,48 +143,43 @@ public interface ITypingRestResource {
      *
      * @param record The PID record.
      *
-     * @return either 200 or 404, indicating whether the profile is registered
-     * or not registered
+     * @return either 201 and a record representation, 409 on validation fail
+     *         (conflict) or 500 on other server errors.
      *
      * @throws IOException
      */
-    @PostMapping(path = "/pid/", consumes = {MediaType.APPLICATION_JSON_VALUE}, produces = {MediaType.APPLICATION_JSON_VALUE})
-    @Operation(summary = "Create a new PID record", description = "Create a new PID record using the record information from the request body.")
+    @PostMapping(
+        path = "/pid/",
+        consumes = {MediaType.APPLICATION_JSON_VALUE, SimplePidRecord.CONTENT_TYPE},
+        produces = {MediaType.APPLICATION_JSON_VALUE, SimplePidRecord.CONTENT_TYPE}
+    )
+    @Operation(
+        summary = "Create a new PID record",
+        description = "Create a new PID record using the record information from the request body."
+    )
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+        description = "The body containing all PID record values as they should be in the new PIDs record.",
+        required = true,
+        content = {
+            @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = PIDRecord.class)),
+            @Content(mediaType = SimplePidRecord.CONTENT_TYPE, schema = @Schema(implementation = SimplePidRecord.class))
+        }
+    )
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "201", description = "Created", content = @Content(mediaType = "application/json", schema = @Schema(implementation = PIDRecord.class))),
+        @ApiResponse(
+            responseCode = "201",
+            description = "Created",
+            content = {
+                @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = PIDRecord.class)),
+                @Content(mediaType = SimplePidRecord.CONTENT_TYPE, schema = @Schema(implementation = SimplePidRecord.class))
+        }),
         @ApiResponse(responseCode = "409", description = "Validation failed (conflict). See body for details.", content = @Content(mediaType = "text/plain")),
         @ApiResponse(responseCode = "500", description = "Server error. See body for details.", content = @Content(mediaType = "text/plain"))
     })
-    public ResponseEntity<PIDRecord> createPID(@RequestBody final PIDRecord record,
-            final WebRequest request,
-            final HttpServletResponse response,
-            final UriComponentsBuilder uriBuilder
-    ) throws IOException;
-
-    /**
-     * Create a new PID using the record information provided in the request
-     * body. The record is expected to contain the identifier of the matching
-     * profile. Before creating the record, the record information will be
-     * validated against the profile.
-     *
-     * @param rec The PID record.
-     *
-     * @return either 200 or 404, indicating whether the profile is registered
-     * or not registered
-     *
-     * @throws IOException
-     */
-    @PostMapping(path = "/pid/", consumes={SimplePidRecord.CONTENT_TYPE}, produces={SimplePidRecord.CONTENT_TYPE})
-    @Operation(summary = "Create a new PID record", description = "Create a new PID record using the record information from the request body.")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "201", description = "Created", content = @Content(mediaType = SimplePidRecord.CONTENT_TYPE, schema = @Schema(implementation = SimplePidRecord.class))),
-        @ApiResponse(responseCode = "409", description = "Validation failed (conflict). See body for details.", content = @Content(mediaType = "text/plain")),
-        @ApiResponse(responseCode = "500", description = "Server error. See body for details.", content = @Content(mediaType = "text/plain"))
-    })
-    public ResponseEntity<SimplePidRecord> createPIDFromSimpleFormat(
+    public ResponseEntity<PIDRecord> createPID(
             @RequestBody
-            final SimplePidRecord rec,
-            
+            final PIDRecord rec,
+
             final WebRequest request,
             final HttpServletResponse response,
             final UriComponentsBuilder uriBuilder
@@ -206,9 +201,26 @@ public interface ITypingRestResource {
         consumes = {MediaType.APPLICATION_JSON_VALUE, SimplePidRecord.CONTENT_TYPE},
         produces = {MediaType.APPLICATION_JSON_VALUE, SimplePidRecord.CONTENT_TYPE}
     )
-    @Operation(summary = "Update an existing PID record", description = "Update an existing PID record using the record information from the request body.")
+    @Operation(
+        summary = "Update an existing PID record",
+        description = "Update an existing PID record using the record information from the request body."
+    )
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+        description = "The body containing all PID record values as they should be after the update.",
+        required = true,
+        content = {
+            @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = PIDRecord.class)),
+            @Content(mediaType = SimplePidRecord.CONTENT_TYPE, schema = @Schema(implementation = SimplePidRecord.class))
+        }
+    )
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Success.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = PIDRecord.class))),
+        @ApiResponse(
+            responseCode = "200",
+            description = "Success.",
+            content = {
+                @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = PIDRecord.class)),
+                @Content(mediaType = SimplePidRecord.CONTENT_TYPE, schema = @Schema(implementation = SimplePidRecord.class))
+            }),
         @ApiResponse(responseCode = "409", description = "Validation failed (conflict). See body for details.", content = @Content(mediaType = "text/plain")),
         @ApiResponse(responseCode = "500", description = "Server error. See body for details.", content = @Content(mediaType = "text/plain"))
     })
@@ -252,32 +264,23 @@ public interface ITypingRestResource {
      *
      * @throws IOException
      */
-    @RequestMapping(path = "/pid/**", method = RequestMethod.GET)
+    @GetMapping(
+        path = "/pid/**",
+        produces = {MediaType.APPLICATION_JSON_VALUE, SimplePidRecord.CONTENT_TYPE}
+    )
     @Operation(summary = "Get the record of the given PID.", description = "Get the record to the given PID, if it exists.")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = PIDRecord.class))),
+        @ApiResponse(
+            responseCode = "200",
+            description = "Found",
+            content = {
+                @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = PIDRecord.class)),
+                @Content(mediaType = SimplePidRecord.CONTENT_TYPE, schema = @Schema(implementation = SimplePidRecord.class))
+            }
+        ),
         @ApiResponse(responseCode = "404", description = "Not found", content = @Content(mediaType = "text/plain"))
     })
     public ResponseEntity<PIDRecord> getRecord (
-            final WebRequest request,
-            final HttpServletResponse response,
-            final UriComponentsBuilder uriBuilder
-    ) throws IOException;
-
-    /**
-     * Get the record of the given PID.
-     *
-     * @return the record.
-     *
-     * @throws IOException
-     */
-    @GetMapping(path = "/pid/**", produces={SimplePidRecord.CONTENT_TYPE}, headers = "Accept=" + SimplePidRecord.CONTENT_TYPE)
-    @Operation(summary = "Get the record of the given PID.", description = "Get the record to the given PID, if it exists.")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Found", content = @Content(mediaType = SimplePidRecord.CONTENT_TYPE, schema = @Schema(implementation = SimplePidRecord.class))),
-        @ApiResponse(responseCode = "404", description = "Not found", content = @Content(mediaType = "text/plain"))
-    })
-    public ResponseEntity<SimplePidRecord> getSimpleRecord (
             final WebRequest request,
             final HttpServletResponse response,
             final UriComponentsBuilder uriBuilder

--- a/src/main/java/edu/kit/datamanager/pit/web/ITypingRestResource.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/ITypingRestResource.java
@@ -35,8 +35,10 @@ import java.util.List;
 import javax.servlet.http.HttpServletResponse;
 
 import org.springdoc.core.converters.models.PageableAsQueryParam;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -145,7 +147,7 @@ public interface ITypingRestResource {
      *
      * @throws IOException
      */
-    @RequestMapping(path = "/pid/", method = RequestMethod.POST)
+    @PostMapping(path = "/pid/", consumes = {MediaType.APPLICATION_JSON_VALUE}, produces = {MediaType.APPLICATION_JSON_VALUE})
     @Operation(summary = "Create a new PID record", description = "Create a new PID record using the record information from the request body.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "201", description = "Created", content = @Content(mediaType = "application/json", schema = @Schema(implementation = PIDRecord.class))),
@@ -153,6 +155,35 @@ public interface ITypingRestResource {
         @ApiResponse(responseCode = "500", description = "Server error. See body for details.", content = @Content(mediaType = "text/plain"))
     })
     public ResponseEntity<PIDRecord> createPID(@RequestBody final PIDRecord record,
+            final WebRequest request,
+            final HttpServletResponse response,
+            final UriComponentsBuilder uriBuilder
+    ) throws IOException;
+
+    /**
+     * Create a new PID using the record information provided in the request
+     * body. The record is expected to contain the identifier of the matching
+     * profile. Before creating the record, the record information will be
+     * validated against the profile.
+     *
+     * @param rec The PID record.
+     *
+     * @return either 200 or 404, indicating whether the profile is registered
+     * or not registered
+     *
+     * @throws IOException
+     */
+    @PostMapping(path = "/pid/", consumes={SimplePidRecord.CONTENT_TYPE}, produces={SimplePidRecord.CONTENT_TYPE})
+    @Operation(summary = "Create a new PID record", description = "Create a new PID record using the record information from the request body.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "Created", content = @Content(mediaType = SimplePidRecord.CONTENT_TYPE, schema = @Schema(implementation = SimplePidRecord.class))),
+        @ApiResponse(responseCode = "409", description = "Validation failed (conflict). See body for details.", content = @Content(mediaType = "text/plain")),
+        @ApiResponse(responseCode = "500", description = "Server error. See body for details.", content = @Content(mediaType = "text/plain"))
+    })
+    public ResponseEntity<SimplePidRecord> createPIDFromSimpleFormat(
+            @RequestBody
+            final SimplePidRecord rec,
+            
             final WebRequest request,
             final HttpServletResponse response,
             final UriComponentsBuilder uriBuilder

--- a/src/main/java/edu/kit/datamanager/pit/web/ITypingRestResource.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/ITypingRestResource.java
@@ -39,6 +39,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -200,14 +201,21 @@ public interface ITypingRestResource {
      *
      * @throws IOException
      */
-    @RequestMapping(path = "/pid/**", method = RequestMethod.PUT)
+    @PutMapping(
+        path = "/pid/**",
+        consumes = {MediaType.APPLICATION_JSON_VALUE, SimplePidRecord.CONTENT_TYPE},
+        produces = {MediaType.APPLICATION_JSON_VALUE, SimplePidRecord.CONTENT_TYPE}
+    )
     @Operation(summary = "Update an existing PID record", description = "Update an existing PID record using the record information from the request body.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Success.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = PIDRecord.class))),
         @ApiResponse(responseCode = "409", description = "Validation failed (conflict). See body for details.", content = @Content(mediaType = "text/plain")),
         @ApiResponse(responseCode = "500", description = "Server error. See body for details.", content = @Content(mediaType = "text/plain"))
     })
-    public ResponseEntity<PIDRecord> updatePID(@RequestBody final PIDRecord record,
+    public ResponseEntity<PIDRecord> updatePID(
+            @RequestBody
+            final PIDRecord rec,
+
             final WebRequest request,
             final HttpServletResponse response,
             final UriComponentsBuilder uriBuilder

--- a/src/main/java/edu/kit/datamanager/pit/web/ITypingRestResource.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/ITypingRestResource.java
@@ -190,7 +190,7 @@ public interface ITypingRestResource {
      * body. The record is expected to contain the identifier of the matching
      * profile. Conditions for a valid record are the same as for creation.
      *
-     * @param record The PID record.
+     * @param rec The PID record.
      *
      * @return the record (on success).
      *

--- a/src/main/java/edu/kit/datamanager/pit/web/ITypingRestResource.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/ITypingRestResource.java
@@ -19,7 +19,7 @@ import edu.kit.datamanager.pit.domain.TypeDefinition;
 import edu.kit.datamanager.pit.pidlog.KnownPid;
 import edu.kit.datamanager.pit.common.InconsistentRecordsException;
 import edu.kit.datamanager.pit.domain.PIDRecord;
-
+import edu.kit.datamanager.pit.domain.SimplePidRecord;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -225,6 +225,24 @@ public interface ITypingRestResource {
             final UriComponentsBuilder uriBuilder
     ) throws IOException;
 
+    /**
+     * Get the record of the given PID.
+     *
+     * @return the record.
+     *
+     * @throws IOException
+     */
+    @GetMapping(path = "/pid/**", produces={SimplePidRecord.CONTENT_TYPE}, headers = "Accept=" + SimplePidRecord.CONTENT_TYPE)
+    @Operation(summary = "Get the record of the given PID.", description = "Get the record to the given PID, if it exists.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Found", content = @Content(mediaType = SimplePidRecord.CONTENT_TYPE, schema = @Schema(implementation = SimplePidRecord.class))),
+        @ApiResponse(responseCode = "404", description = "Not found", content = @Content(mediaType = "text/plain"))
+    })
+    public ResponseEntity<SimplePidRecord> getSimpleRecord (
+            final WebRequest request,
+            final HttpServletResponse response,
+            final UriComponentsBuilder uriBuilder
+    ) throws IOException;
 
     /**
      * Requests a PID from the local store. If this PID is known, it will be

--- a/src/main/java/edu/kit/datamanager/pit/web/converter/SimplePidRecordConverter.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/converter/SimplePidRecordConverter.java
@@ -1,0 +1,95 @@
+package edu.kit.datamanager.pit.web.converter;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+
+import edu.kit.datamanager.pit.Application;
+import edu.kit.datamanager.pit.domain.PIDRecord;
+import edu.kit.datamanager.pit.domain.SimplePidRecord;
+
+/**
+ * Converts to-and-from PIDRecord format when SimplePidRecord format is actually
+ * expected.
+ * 
+ * Do not use explicitly. Spring will use it, as explained below.
+ * 
+ * The idea is that all handlers in the REST API simply expect a serialized
+ * (marshalled) version of a PID record. This is not always true, though. The
+ * PIDRecord representation is pretty complex. To offer a simpler format,
+ * `SimplePidRecord` was introduced. To avoid larger modifications within the
+ * code, and to not break the API, the simple format comes into play only when
+ * its content type is being used.
+ * 
+ * If the client wants to send in the simple format, it needs to set the
+ * content-type header accordingly. Spring will then use this converter to
+ * convert it directly into a PIDRecord instance, as the handler expects. This
+ * way only one handler must be used for multiple formats.
+ * 
+ * For accepting formats, it is the same. With the accept header, a client may
+ * control which format it would like to receive. If it prefers to receive the
+ * simple format and sets the header accordingly, instead of directly
+ * serializing the PIDRecord, this class will be used. It first converts the
+ * record into the simple class representation before serializing into JSON.
+ */
+public class SimplePidRecordConverter implements HttpMessageConverter<PIDRecord> {
+
+    private Logger LOGGER = LoggerFactory.getLogger(SimplePidRecordConverter.class);
+
+    private boolean isValidMediaType(MediaType arg1) {
+        return arg1.toString().contains(SimplePidRecord.CONTENT_TYPE_PURE);
+    }
+
+    @Override
+    public boolean canRead(Class<?> arg0, MediaType arg1) {
+        if (arg0 == null || arg1 == null) {
+            return false;
+        }
+        LOGGER.trace("canRead: Checking applicability for class {} and mediatype {}.", arg0, arg1);
+        return PIDRecord.class.equals(arg0) && isValidMediaType(arg1);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> arg0, MediaType arg1) {
+        LOGGER.trace("canWrite: Checking applicability for class {} and mediatype {}.", arg0, arg1);
+        return PIDRecord.class.equals(arg0) && isValidMediaType(arg1);
+    }
+
+    @Override
+    public List<MediaType> getSupportedMediaTypes() {
+        return Arrays.asList(
+                MediaType.valueOf(SimplePidRecord.CONTENT_TYPE)
+        );
+    }
+
+    @Override
+    public PIDRecord read(Class<? extends PIDRecord> arg0, HttpInputMessage arg1)
+            throws IOException, HttpMessageNotReadableException {
+        LOGGER.trace("Resing HttpInputMessage for JOLT transformation.");
+        try (InputStreamReader reader = new InputStreamReader(arg1.getBody(), StandardCharsets.UTF_8)) {
+            String data = new BufferedReader(reader).lines().collect(Collectors.joining("\n"));
+            return new PIDRecord(Application.jsonObjectMapper().readValue(data, SimplePidRecord.class));
+        }
+    }
+
+    @Override
+    public void write(PIDRecord arg0, MediaType arg1, HttpOutputMessage arg2)
+            throws IOException, HttpMessageNotWritableException {
+        SimplePidRecord sim = new SimplePidRecord(arg0);
+        byte[] simSerialized = Application.jsonObjectMapper().writeValueAsBytes(sim);
+        arg2.getBody().write(simSerialized);
+    }
+}

--- a/src/main/java/edu/kit/datamanager/pit/web/converter/SimplePidRecordConverter.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/converter/SimplePidRecordConverter.java
@@ -47,7 +47,7 @@ import edu.kit.datamanager.pit.domain.SimplePidRecord;
  */
 public class SimplePidRecordConverter implements HttpMessageConverter<PIDRecord> {
 
-    private Logger LOGGER = LoggerFactory.getLogger(SimplePidRecordConverter.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SimplePidRecordConverter.class);
 
     private boolean isValidMediaType(MediaType arg1) {
         return arg1.toString().contains(SimplePidRecord.CONTENT_TYPE_PURE);
@@ -78,7 +78,7 @@ public class SimplePidRecordConverter implements HttpMessageConverter<PIDRecord>
     @Override
     public PIDRecord read(Class<? extends PIDRecord> arg0, HttpInputMessage arg1)
             throws IOException, HttpMessageNotReadableException {
-        LOGGER.trace("Resing HttpInputMessage for JOLT transformation.");
+        LOGGER.trace("Read simple message from client and convert to PIDRecord.");
         try (InputStreamReader reader = new InputStreamReader(arg1.getBody(), StandardCharsets.UTF_8)) {
             String data = new BufferedReader(reader).lines().collect(Collectors.joining("\n"));
             return new PIDRecord(Application.jsonObjectMapper().readValue(data, SimplePidRecord.class));
@@ -88,6 +88,7 @@ public class SimplePidRecordConverter implements HttpMessageConverter<PIDRecord>
     @Override
     public void write(PIDRecord arg0, MediaType arg1, HttpOutputMessage arg2)
             throws IOException, HttpMessageNotWritableException {
+        LOGGER.trace("Write PIDRecord to simple format for client.");
         SimplePidRecord sim = new SimplePidRecord(arg0);
         byte[] simSerialized = Application.jsonObjectMapper().writeValueAsBytes(sim);
         arg2.getBody().write(simSerialized);

--- a/src/main/java/edu/kit/datamanager/pit/web/impl/TypingRESTResourceImpl.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/impl/TypingRESTResourceImpl.java
@@ -446,6 +446,18 @@ public class TypingRESTResourceImpl implements ITypingRestResource {
     }
 
     @Override
+    public ResponseEntity<SimplePidRecord> createPIDFromSimpleFormat(
+            final SimplePidRecord rec,
+            final WebRequest request,
+            final HttpServletResponse response,
+            final UriComponentsBuilder uriBuilder
+    ) throws IOException {
+        ResponseEntity<PIDRecord> oldFormat = this.createPID(new PIDRecord(rec), request, response, uriBuilder);
+        SimplePidRecord simpleFormat = new SimplePidRecord(oldFormat.getBody());
+        return ResponseEntity.status(HttpStatus.CREATED.value()).body(simpleFormat);
+    }
+
+    @Override
     public ResponseEntity<PIDRecord> updatePID(
             PIDRecord record,
             final WebRequest request,

--- a/src/main/java/edu/kit/datamanager/pit/web/impl/TypingRESTResourceImpl.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/impl/TypingRESTResourceImpl.java
@@ -15,6 +15,7 @@ import edu.kit.datamanager.pit.configuration.ApplicationProperties.ValidationStr
 import edu.kit.datamanager.pit.common.PidNotFoundException;
 import edu.kit.datamanager.pit.common.RecordValidationException;
 import edu.kit.datamanager.pit.domain.PIDRecord;
+import edu.kit.datamanager.pit.domain.SimplePidRecord;
 import edu.kit.datamanager.pit.domain.TypeDefinition;
 import edu.kit.datamanager.pit.pidlog.KnownPid;
 import edu.kit.datamanager.pit.pidlog.KnownPidsDao;
@@ -552,6 +553,17 @@ public class TypingRESTResourceImpl implements ITypingRestResource {
             storeLocally(pid, false);
         }
         return ResponseEntity.ok().body(record);
+    }
+
+    @Override
+    public ResponseEntity<SimplePidRecord> getSimpleRecord (
+            final WebRequest request,
+            final HttpServletResponse response,
+            final UriComponentsBuilder uriBuilder
+    ) throws IOException {
+        ResponseEntity<PIDRecord> oldFormat = this.getRecord(request, response, uriBuilder);
+        SimplePidRecord newFormat = new SimplePidRecord(oldFormat.getBody());
+        return ResponseEntity.ok(newFormat);
     }
 
     @Override

--- a/src/main/java/edu/kit/datamanager/pit/web/impl/TypingRESTResourceImpl.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/impl/TypingRESTResourceImpl.java
@@ -32,6 +32,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.client.cache.HeaderConstants;
+import org.apache.http.entity.ContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -552,6 +553,7 @@ public class TypingRESTResourceImpl implements ITypingRestResource {
         if (applicationProps.getStorageStrategy().storesResolved()) {
             storeLocally(pid, false);
         }
+        response.setContentType(ContentType.APPLICATION_JSON.toString());
         return ResponseEntity.ok().body(record);
     }
 
@@ -563,6 +565,7 @@ public class TypingRESTResourceImpl implements ITypingRestResource {
     ) throws IOException {
         ResponseEntity<PIDRecord> oldFormat = this.getRecord(request, response, uriBuilder);
         SimplePidRecord newFormat = new SimplePidRecord(oldFormat.getBody());
+        response.setContentType(SimplePidRecord.CONTENT_TYPE);
         return ResponseEntity.ok(newFormat);
     }
 

--- a/src/main/java/edu/kit/datamanager/pit/web/impl/TypingRESTResourceImpl.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/impl/TypingRESTResourceImpl.java
@@ -446,18 +446,6 @@ public class TypingRESTResourceImpl implements ITypingRestResource {
     }
 
     @Override
-    public ResponseEntity<SimplePidRecord> createPIDFromSimpleFormat(
-            final SimplePidRecord rec,
-            final WebRequest request,
-            final HttpServletResponse response,
-            final UriComponentsBuilder uriBuilder
-    ) throws IOException {
-        ResponseEntity<PIDRecord> oldFormat = this.createPID(new PIDRecord(rec), request, response, uriBuilder);
-        SimplePidRecord simpleFormat = new SimplePidRecord(oldFormat.getBody());
-        return ResponseEntity.status(HttpStatus.CREATED.value()).body(simpleFormat);
-    }
-
-    @Override
     public ResponseEntity<PIDRecord> updatePID(
             PIDRecord record,
             final WebRequest request,
@@ -561,24 +549,11 @@ public class TypingRESTResourceImpl implements ITypingRestResource {
             final HttpServletResponse response,
             final UriComponentsBuilder uriBuilder) throws IOException {
         String pid = getContentPathFromRequest("pid", request);
-        PIDRecord record = this.typingService.queryAllProperties(pid);
+        PIDRecord rec = this.typingService.queryAllProperties(pid);
         if (applicationProps.getStorageStrategy().storesResolved()) {
             storeLocally(pid, false);
         }
-        response.setContentType(ContentType.APPLICATION_JSON.toString());
-        return ResponseEntity.ok().body(record);
-    }
-
-    @Override
-    public ResponseEntity<SimplePidRecord> getSimpleRecord (
-            final WebRequest request,
-            final HttpServletResponse response,
-            final UriComponentsBuilder uriBuilder
-    ) throws IOException {
-        ResponseEntity<PIDRecord> oldFormat = this.getRecord(request, response, uriBuilder);
-        SimplePidRecord newFormat = new SimplePidRecord(oldFormat.getBody());
-        response.setContentType(SimplePidRecord.CONTENT_TYPE);
-        return ResponseEntity.ok(newFormat);
+        return ResponseEntity.ok().body(rec);
     }
 
     @Override

--- a/src/test/java/edu/kit/datamanager/pit/domain/SimplePidRecordTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/domain/SimplePidRecordTest.java
@@ -1,0 +1,12 @@
+package edu.kit.datamanager.pit.domain;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class SimplePidRecordTest {
+    @Test
+    void testContentTypeConstant() {
+        assertTrue(SimplePidRecord.CONTENT_TYPE.contains(SimplePidRecord.CONTENT_TYPE_PURE));
+    }
+}

--- a/src/test/java/edu/kit/datamanager/pit/pidsystem/impl/sandbox/PidDatabaseObjectTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/pidsystem/impl/sandbox/PidDatabaseObjectTest.java
@@ -1,0 +1,34 @@
+package edu.kit.datamanager.pit.pidsystem.impl.sandbox;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.core.JacksonException;
+
+import edu.kit.datamanager.pit.web.ApiMockUtils;
+
+@SpringBootTest
+@TestPropertySource("/test/application-test.properties")
+@ActiveProfiles("test")
+public class PidDatabaseObjectTest {
+    @Autowired
+    private PidDatabaseObjectDao dao;
+
+    @BeforeEach
+    public void setUp() {
+        //prepareDataBase();
+        dao.deleteAll();
+    }
+
+    @Test
+    @Transactional
+    void testStorePidDatabaseObject() throws JacksonException {
+        PidDatabaseObject dbo = new PidDatabaseObject(ApiMockUtils.getSomePidRecordInstance());
+        dao.saveAndFlush(dbo);
+    }
+}

--- a/src/test/java/edu/kit/datamanager/pit/web/ApiMockUtils.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/ApiMockUtils.java
@@ -56,7 +56,7 @@ public class ApiMockUtils {
 
     /**
      * Wrapper to query known PIDs via API given time intervals for the creation
-     * timestamp and modification timestamp. This is a reusable test component.
+     * timestamp and modification timestamp.
      * 
      * @param createdAfter   lower end for the creation timestamp interval
      * @param createdBefore  upper end for the creation timestamp interval
@@ -139,8 +139,7 @@ public class ApiMockUtils {
     }
 
     /**
-     * Updates a PID record and makes some generic tests. This is a reusable test
-     * component.
+     * Updates a PID record and makes some generic tests.
      * 
      * @param record the record, containing the information as it should be after
      *               the update.
@@ -224,7 +223,7 @@ public class ApiMockUtils {
      * @throws Exception if any assumption breaks.
      */
     public static PIDRecord createSomeRecord(MockMvc mockMvc) throws Exception {
-        String createdBody = ApiMockUtils.createRecord(mockMvc, ApiMockUtils.JSON_RECORD, null, null);
+        String createdBody = ApiMockUtils.createRecord(mockMvc, ApiMockUtils.JSON_RECORD, MediaType.APPLICATION_JSON_VALUE, MediaType.ALL_VALUE);
         PIDRecord createdRecord = getJsonMapper().readValue(createdBody, PIDRecord.class);
         String createdPid = createdRecord.getPid();
         assertFalse(createdPid.isEmpty());
@@ -235,8 +234,9 @@ public class ApiMockUtils {
      * Generic method to do a "create" request.
      * 
      * @param mockMvc instance that mocks the REST API
-     * @param acceptContentType if empty or null, defaults to ALL
-     * @param bodyContentType if empty or null, defaults to JSON
+     * @param body the PID record to create
+     * @param bodyContentType type of the body
+     * @param acceptContentType type to expect
      * @return the body of the response as string.
      * @throws Exception on any error.
      */
@@ -245,8 +245,8 @@ public class ApiMockUtils {
             .contentType(MediaType.APPLICATION_JSON)
             .characterEncoding("utf-8")
             .content(body);
-            boolean hasAcceptContentType = acceptContentType != null && !acceptContentType.isEmpty();
-            boolean hasBodyContentType = bodyContentType != null && !bodyContentType.isEmpty();
+        boolean hasAcceptContentType = acceptContentType != null && !acceptContentType.isEmpty();
+        boolean hasBodyContentType = bodyContentType != null && !bodyContentType.isEmpty();
         if (hasAcceptContentType) {
             request = request.accept(acceptContentType);
         } else {

--- a/src/test/java/edu/kit/datamanager/pit/web/ApiMockUtils.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/ApiMockUtils.java
@@ -1,0 +1,239 @@
+package edu.kit.datamanager.pit.web;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+
+import edu.kit.datamanager.pit.pidlog.KnownPid;
+import edu.kit.datamanager.pit.Application;
+import edu.kit.datamanager.pit.domain.PIDRecord;
+import edu.kit.datamanager.pit.domain.SimplePidRecord;
+
+/**
+ * A collection of reusable test components.
+ * 
+ * Usually methods wrapping often-used mockMvc calls.
+ */
+public class ApiMockUtils {
+
+    static final String JSON_RECORD = "{\"entries\":{\"21.T11148/076759916209e5d62bd5\":[{\"key\":\"21.T11148/076759916209e5d62bd5\",\"name\":\"kernelInformationProfile\",\"value\":\"21.T11148/301c6f04763a16f0f72a\"}],\"21.T11148/397d831aa3a9d18eb52c\":[{\"key\":\"21.T11148/397d831aa3a9d18eb52c\",\"name\":\"dateModified\",\"value\":\"2021-12-21T17:36:09.541+00:00\"}],\"21.T11148/8074aed799118ac263ad\":[{\"key\":\"21.T11148/8074aed799118ac263ad\",\"name\":\"digitalObjectPolicy\",\"value\":\"21.T11148/37d0f4689c6ea3301787\"}],\"21.T11148/92e200311a56800b3e47\":[{\"key\":\"21.T11148/92e200311a56800b3e47\",\"name\":\"etag\",\"value\":\"{ \\\"sha256sum\\\": \\\"sha256 c50624fd5ddd2b9652b72e2d2eabcb31a54b777718ab6fb7e44b582c20239a7c\\\" }\"}],\"21.T11148/aafd5fb4c7222e2d950a\":[{\"key\":\"21.T11148/aafd5fb4c7222e2d950a\",\"name\":\"dateCreated\",\"value\":\"2021-12-21T17:36:09.541+00:00\"}],\"21.T11148/b8457812905b83046284\":[{\"key\":\"21.T11148/b8457812905b83046284\",\"name\":\"digitalObjectLocation\",\"value\":\"https://test.repo/file001\"}],\"21.T11148/c692273deb2772da307f\":[{\"key\":\"21.T11148/c692273deb2772da307f\",\"name\":\"version\",\"value\":\"1.0.0\"}],\"21.T11148/c83481d4bf467110e7c9\":[{\"key\":\"21.T11148/c83481d4bf467110e7c9\",\"name\":\"digitalObjectType\",\"value\":\"21.T11148/ManuscriptPage\"}]},\"pid\":\"unregistered-18622\"}";
+
+    /**
+     * Retrieves an object mapper which is the same as the bean in the
+     * application context, from a functional point of view.
+     */
+    public static ObjectMapper getJsonMapper() {
+        return Application.jsonObjectMapper();
+    }
+
+    /**
+     * Wrapper to query known PIDs via API given time intervals for the creation
+     * timestamp and modification timestamp. This is a reusable test component.
+     * 
+     * @param createdAfter   lower end for the creation timestamp interval
+     * @param createdBefore  upper end for the creation timestamp interval
+     * @param modifiedAfter  lower end for the modification timestamp interval
+     * @param modifiedBefore upper end for the modification timestamp interval
+     * @param pageable       an optional parameter to indicate the page which should
+     *                       be returned
+     * @return the result of the query
+     * @throws Exception on failed assumptions
+     */
+    public static List<KnownPid> queryKnownPIDs(
+        MockMvc mockMvc,
+        Instant createdAfter,
+        Instant createdBefore,
+        Instant modifiedAfter,
+        Instant modifiedBefore,
+        Optional<Pageable> pageable
+    ) throws Exception {
+        MockHttpServletRequestBuilder request =  get("/api/v1/pit/known-pid/");
+        if (pageable.isPresent()) {
+            request.param("page", String.valueOf(pageable.get().getPageNumber()));
+            request.param("size", String.valueOf(pageable.get().getPageSize()));
+        }
+        if (createdAfter != null) {
+            request.param("created_after", String.valueOf(createdAfter));
+        }
+        if (createdBefore != null) {
+            request.param("created_before", String.valueOf(createdBefore));
+        }
+        if (modifiedAfter != null) {
+            request.param("modified_after", String.valueOf(modifiedAfter));
+        }
+        if (modifiedBefore != null) {
+            request.param("modified_before", String.valueOf(modifiedBefore));
+        }
+        MvcResult result = mockMvc.perform(request)
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        List<KnownPid> pidinfos = Arrays.asList(getJsonMapper().readerForArrayOf(KnownPid.class).readValue(body));
+        return pidinfos;
+    }
+
+    public static JsonNode queryKnownPIDsInTabulatorFormat(
+        MockMvc mockMvc,
+        Instant createdAfter,
+        Instant createdBefore,
+        Instant modifiedAfter,
+        Instant modifiedBefore,
+        Optional<Pageable> pageable
+    ) throws Exception {
+        MockHttpServletRequestBuilder request =  get("/api/v1/pit/known-pid/");
+        if (pageable.isPresent()) {
+            request.param("page", String.valueOf(pageable.get().getPageNumber()));
+            request.param("size", String.valueOf(pageable.get().getPageSize()));
+        }
+        if (createdAfter != null) {
+            request.param("created_after", String.valueOf(createdAfter));
+        }
+        if (createdBefore != null) {
+            request.param("created_before", String.valueOf(createdBefore));
+        }
+        if (modifiedAfter != null) {
+            request.param("modified_after", String.valueOf(modifiedAfter));
+        }
+        if (modifiedBefore != null) {
+            request.param("modified_before", String.valueOf(modifiedBefore));
+        }
+        request.accept("application/tabulator+json");
+
+        MvcResult result = mockMvc.perform(request)
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        return getJsonMapper().readTree(body);
+    }
+
+    /**
+     * Updates a PID record and makes some generic tests. This is a reusable test
+     * component.
+     * 
+     * @param record the record, containing the information as it should be after
+     *               the update.
+     * @return the record as it is after the update.
+     * @throws Exception if any assumption breaks. Do not catch, let your test fail
+     *                   if this happens.
+     */
+    public static PIDRecord updateRecord(MockMvc mockMvc, PIDRecord record) throws Exception {
+        assertFalse(record.getPid().isEmpty());
+        MvcResult updated = mockMvc
+                .perform(
+                    put("/api/v1/pit/pid/" + record.getPid())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(getJsonMapper().writeValueAsString(record))
+                        .accept(MediaType.ALL)
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+            
+        String body = updated.getResponse().getContentAsString();
+        PIDRecord updatedRecord = getJsonMapper().readValue(body, PIDRecord.class);
+        return updatedRecord;
+    }
+
+    /**
+     * Resolves a record using the REST API and MockMvc.
+     * 
+     * @param mockMvc instance that mocks the REST API.
+     * @param pid the PID to resolve
+     * @return the resolved record of the given PID.
+     * @throws Exception if any assumption breaks. Do not catch, let your test fail
+     *                   if this happens.
+     */
+    public static PIDRecord resolveRecord(MockMvc mockMvc, String pid) throws Exception {
+        String resolvedBody = ApiMockUtils.resolveRecord(mockMvc, pid, null);
+        PIDRecord resolvedRecord = getJsonMapper().readValue(resolvedBody, PIDRecord.class);
+        return resolvedRecord;
+    }
+
+    /**
+     * Resolves a record using the REST API and MockMvc.
+     * 
+     * @param mockMvc instance that mocks the REST API.
+     * @param pid the PID to resolve
+     * @return the resolved record of the given PID.
+     * @throws Exception if any assumption breaks. Do not catch, let your test fail
+     *                   if this happens.
+     */
+    public static SimplePidRecord resolveSimpleRecord(MockMvc mockMvc, String pid) throws Exception {
+        String resolvedBody = ApiMockUtils.resolveRecord(mockMvc, pid, SimplePidRecord.CONTENT_TYPE);
+        SimplePidRecord resolvedRecord = getJsonMapper().readValue(resolvedBody, SimplePidRecord.class);
+        return resolvedRecord;
+    }
+
+    /**
+     * Resolves a record using the REST API and MockMvc.
+     * 
+     * @param mockMvc instance that mocks the REST API.
+     * @param createdPid the PID to resolve.
+     * @param contentType the content type for the request.
+     * @return the resolved record of the given PID.
+     * @throws Exception if any assumption breaks. Do not catch, let your test fail
+     *                   if this happens.
+     */
+    public static String resolveRecord(MockMvc mockMvc, String pid, String contentType) throws Exception {
+        var get = get("/api/v1/pit/pid/".concat(pid));
+        if (contentType != null && !contentType.isEmpty()) {
+            get = get.contentType(contentType);
+        }
+        MvcResult resolved = mockMvc
+            .perform(get)
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andReturn();
+        return resolved.getResponse().getContentAsString();
+    }
+
+    /**
+     * Creates a record and does make some generic tests. This is a reusable test
+     * component.
+     * 
+     * @return The created PID record.
+     * @throws Exception if any assumption breaks. Do not catch, let your test fail
+     *                   if this happens.
+     */
+    public static PIDRecord createSomeRecord(MockMvc mockMvc) throws Exception {
+        MvcResult created = mockMvc
+                .perform(
+                    post("/api/v1/pit/pid/")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(JSON_RECORD)
+                        .accept(MediaType.ALL)
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andReturn();
+            
+        String createdBody = created.getResponse().getContentAsString();
+        PIDRecord createdRecord = getJsonMapper().readValue(createdBody, PIDRecord.class);
+        String createdPid = createdRecord.getPid();
+        assertFalse(createdPid.isEmpty());
+        return createdRecord;
+    }
+}

--- a/src/test/java/edu/kit/datamanager/pit/web/ApiMockUtils.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/ApiMockUtils.java
@@ -197,12 +197,12 @@ public class ApiMockUtils {
      *                   if this happens.
      */
     public static String resolveRecord(MockMvc mockMvc, String pid, String contentType) throws Exception {
-        var get = get("/api/v1/pit/pid/".concat(pid));
+        MockHttpServletRequestBuilder request = get("/api/v1/pit/pid/".concat(pid));
         if (contentType != null && !contentType.isEmpty()) {
-            get = get.contentType(contentType);
+            request = request.accept(contentType);
         }
         MvcResult resolved = mockMvc
-            .perform(get)
+            .perform(request)
             .andDo(MockMvcResultHandlers.print())
             .andExpect(MockMvcResultMatchers.status().isOk())
             .andReturn();

--- a/src/test/java/edu/kit/datamanager/pit/web/SimpleJSONFormatTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/SimpleJSONFormatTest.java
@@ -118,4 +118,102 @@ class SimpleJSONFormatTest {
         SimplePidRecord sim = ApiMockUtils.getJsonMapper().readValue(responseBody, SimplePidRecord.class);
         assertNotNull(sim);
     }
+
+    /**
+     * Test: Update PID
+     * 
+     * Input: (complex) json
+     * Accept: any
+     * Expect: (complex) json, HTTP 200
+     */
+    @Test
+    void testUpdatePidFromComplexAndAcceptAll() throws Exception {
+        PIDRecord original = ApiMockUtils.createSomeRecord(this.mockMvc);
+        // add digitalObjectLocation, which is a property supported by most profiles.
+        // in future, it would be more reliable to really ask the profile for the pid of this field.
+        original.addEntry("21.T11148/b8457812905b83046284", "", "https://example.com/file2");
+        String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(original);
+        String responseBody = ApiMockUtils.updateRecord(mockMvc, original.getPid(), requestBody, MediaType.APPLICATION_JSON_VALUE, MediaType.ALL_VALUE);
+        PIDRecord sim = ApiMockUtils.getJsonMapper().readValue(responseBody, PIDRecord.class);
+        assertNotNull(sim);
+    }
+
+    /**
+     * Test: Update PID
+     * 
+     * Input: (complex) json
+     * Accept: json
+     * Expect: (complex) json, HTTP 200
+     */
+    @Test
+    void testUpdatePidFromComplexAndAcceptComplex() throws Exception {
+        PIDRecord original = ApiMockUtils.createSomeRecord(this.mockMvc);
+        // add digitalObjectLocation, which is a property supported by most profiles.
+        // in future, it would be more reliable to really ask the profile for the pid of this field.
+        original.addEntry("21.T11148/b8457812905b83046284", "", "https://example.com/file2");
+        String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(original);
+        String responseBody = ApiMockUtils.updateRecord(mockMvc, original.getPid(), requestBody, MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE);
+        PIDRecord modified = ApiMockUtils.getJsonMapper().readValue(responseBody, PIDRecord.class);
+        assertNotNull(modified);
+    }
+
+    /**
+     * Test: Update PID
+     * 
+     * Input: simple json
+     * Accept: json
+     * Expect: simple json, HTTP 200
+     */
+    @Test
+    void testUpdatePidFromSimpleAndAcceptJson() throws Exception {
+        PIDRecord original = ApiMockUtils.createSomeRecord(this.mockMvc);
+        // add digitalObjectLocation, which is a property supported by most profiles.
+        // in future, it would be more reliable to really ask the profile for the pid of this field.
+        original.addEntry("21.T11148/b8457812905b83046284", "", "https://example.com/file2");
+        SimplePidRecord simple = new SimplePidRecord(original);
+        String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(simple);
+        String responseBody = ApiMockUtils.updateRecord(mockMvc, simple.getPid(), requestBody, SimplePidRecord.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+        SimplePidRecord modified = ApiMockUtils.getJsonMapper().readValue(responseBody, SimplePidRecord.class);
+        assertNotNull(modified);
+    }
+
+    /**
+     * Test: Update PID
+     * 
+     * Input: simple json
+     * Accept: simple json
+     * Expect: simple json, HTTP 200
+     */
+    @Test
+    void testUpdatePidFromSimpleAndAcceptSimple() throws Exception {
+        PIDRecord original = ApiMockUtils.createSomeRecord(this.mockMvc);
+        // add digitalObjectLocation, which is a property supported by most profiles.
+        // in future, it would be more reliable to really ask the profile for the pid of this field.
+        original.addEntry("21.T11148/b8457812905b83046284", "", "https://example.com/file2");
+        SimplePidRecord simple = new SimplePidRecord(original);
+        String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(simple);
+        String responseBody = ApiMockUtils.updateRecord(mockMvc, simple.getPid(), requestBody, SimplePidRecord.CONTENT_TYPE, SimplePidRecord.CONTENT_TYPE);
+        SimplePidRecord modified = ApiMockUtils.getJsonMapper().readValue(responseBody, SimplePidRecord.class);
+        assertNotNull(modified);
+    }
+
+    /**
+     * Test: Update PID
+     * 
+     * Input: simple json
+     * Accept: any
+     * Expect: simple json, HTTP 200
+     */
+    @Test
+    void testUpdatePidFromSimpleAndAcceptAll() throws Exception {
+        PIDRecord original = ApiMockUtils.createSomeRecord(this.mockMvc);
+        // add digitalObjectLocation, which is a property supported by most profiles.
+        // in future, it would be more reliable to really ask the profile for the pid of this field.
+        original.addEntry("21.T11148/b8457812905b83046284", "", "https://example.com/file2");
+        SimplePidRecord simple = new SimplePidRecord(original);
+        String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(simple);
+        String responseBody = ApiMockUtils.updateRecord(mockMvc, simple.getPid(), requestBody, SimplePidRecord.CONTENT_TYPE, MediaType.ALL_VALUE);
+        SimplePidRecord modified = ApiMockUtils.getJsonMapper().readValue(responseBody, SimplePidRecord.class);
+        assertNotNull(modified);
+    }
 }

--- a/src/test/java/edu/kit/datamanager/pit/web/SimpleJSONFormatTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/SimpleJSONFormatTest.java
@@ -24,7 +24,7 @@ import edu.kit.datamanager.pit.domain.SimplePidRecord;
 // Set the in-memory implementation
 @TestPropertySource("/test/application-test.properties")
 @ActiveProfiles("test")
-public class SimpleJSONFormatTest {
+class SimpleJSONFormatTest {
 
     @Autowired
     private WebApplicationContext webApplicationContext;
@@ -36,8 +36,11 @@ public class SimpleJSONFormatTest {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.webApplicationContext).build();
     }
 
+    /**
+     * Test: Resolve PID
+     */
     @Test
-    public void testResolvePid() throws Exception {
+    void testResolvePid() throws Exception {
         PIDRecord complexFormat = ApiMockUtils.createSomeRecord(this.mockMvc);
         assertNotNull(complexFormat);
 
@@ -53,12 +56,14 @@ public class SimpleJSONFormatTest {
     }
 
     /**
+     * Test: Create PID
+     * 
      * Input: simple json
      * Accept: simple json
      * Expect: simple json, HTTP 201
      */
     @Test
-    public void testCreatePidFromSimpleAndAcceptSimple() throws Exception {
+    void testCreatePidFromSimpleAndAcceptSimple() throws Exception {
         SimplePidRecord input = new SimplePidRecord(ApiMockUtils.getSomePidRecordInstance());
         String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(input);
         String responseBody = ApiMockUtils.createRecord(mockMvc, requestBody, SimplePidRecord.CONTENT_TYPE, SimplePidRecord.CONTENT_TYPE);
@@ -67,43 +72,49 @@ public class SimpleJSONFormatTest {
     }
 
     /**
+     * Test: Create PID
+     * 
      * Input: simple json
      * Accept: any
      * Expect: simple json, HTTP 201
      */
     @Test
-    public void testCreatePidFromSimpleAndAcceptAll() throws Exception {
+    void testCreatePidFromSimpleAndAcceptAll() throws Exception {
         SimplePidRecord input = new SimplePidRecord(ApiMockUtils.getSomePidRecordInstance());
         String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(input);
-        String responseBody = ApiMockUtils.createRecord(mockMvc, requestBody, SimplePidRecord.CONTENT_TYPE, MediaType.ALL.toString());
+        String responseBody = ApiMockUtils.createRecord(mockMvc, requestBody, SimplePidRecord.CONTENT_TYPE, MediaType.ALL_VALUE);
         SimplePidRecord sim = ApiMockUtils.getJsonMapper().readValue(responseBody, SimplePidRecord.class);
         assertNotNull(sim);
     }
 
     /**
+     * Test: Create PID
+     * 
      * Input: (complex) json
      * Accept: json
      * Expect: (complex) json, HTTP 201
     */
     @Test
-    public void testCreatePidFromComplexAndAcceptJson() throws Exception {
+    void testCreatePidFromComplexAndAcceptJson() throws Exception {
         PIDRecord input = ApiMockUtils.getSomePidRecordInstance();
         String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(input);
-        String responseBody = ApiMockUtils.createRecord(mockMvc, requestBody, MediaType.APPLICATION_JSON.toString(), MediaType.APPLICATION_JSON.toString());
+        String responseBody = ApiMockUtils.createRecord(mockMvc, requestBody, MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE);
         SimplePidRecord sim = ApiMockUtils.getJsonMapper().readValue(responseBody, SimplePidRecord.class);
         assertNotNull(sim);
     }
 
     /**
+     * Test: Create PID
+     * 
      * Input: (complex) json
      * Accept: any
      * Expect: (complex) json, HTTP 201
      */
     @Test
-    public void testCreatePidFromComplexAndAcceptAll() throws Exception {
+    void testCreatePidFromComplexAndAcceptAll() throws Exception {
         PIDRecord input = ApiMockUtils.getSomePidRecordInstance();
         String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(input);
-        String responseBody = ApiMockUtils.createRecord(mockMvc, requestBody, MediaType.APPLICATION_JSON.toString(), MediaType.ALL.toString());
+        String responseBody = ApiMockUtils.createRecord(mockMvc, requestBody, MediaType.APPLICATION_JSON_VALUE, MediaType.ALL_VALUE);
         SimplePidRecord sim = ApiMockUtils.getJsonMapper().readValue(responseBody, SimplePidRecord.class);
         assertNotNull(sim);
     }

--- a/src/test/java/edu/kit/datamanager/pit/web/SimpleJSONFormatTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/SimpleJSONFormatTest.java
@@ -102,9 +102,9 @@ class SimpleJSONFormatTest {
         PIDRecord input = ApiMockUtils.getSomePidRecordInstance();
         String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(input);
         String responseBody = ApiMockUtils.createRecord(mockMvc, requestBody, MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE);
-        SimplePidRecord sim = ApiMockUtils.getJsonMapper().readValue(responseBody, SimplePidRecord.class);
-        assertNotNull(sim);
-        assertNotNull(sim.getPairs());
+        PIDRecord modified = ApiMockUtils.getJsonMapper().readValue(responseBody, PIDRecord.class);
+        assertNotNull(modified);
+        assertTrue(modified.getEntries().size() > 0);
     }
 
     /**
@@ -119,9 +119,9 @@ class SimpleJSONFormatTest {
         PIDRecord input = ApiMockUtils.getSomePidRecordInstance();
         String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(input);
         String responseBody = ApiMockUtils.createRecord(mockMvc, requestBody, MediaType.APPLICATION_JSON_VALUE, MediaType.ALL_VALUE);
-        SimplePidRecord sim = ApiMockUtils.getJsonMapper().readValue(responseBody, SimplePidRecord.class);
-        assertNotNull(sim);
-        assertNotNull(sim.getPairs());
+        PIDRecord modified = ApiMockUtils.getJsonMapper().readValue(responseBody, PIDRecord.class);
+        assertNotNull(modified);
+        assertTrue(modified.getEntries().size() > 0);
     }
 
     /**
@@ -181,8 +181,8 @@ class SimpleJSONFormatTest {
         String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(simple);
         String responseBody = ApiMockUtils.updateRecord(mockMvc, simple.getPid(), requestBody, SimplePidRecord.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
         SimplePidRecord modified = ApiMockUtils.getJsonMapper().readValue(responseBody, SimplePidRecord.class);
-        assertNotNull(modified.getPairs());
         assertNotNull(modified);
+        assertNotNull(modified.getPairs());
     }
 
     /**
@@ -202,8 +202,8 @@ class SimpleJSONFormatTest {
         String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(simple);
         String responseBody = ApiMockUtils.updateRecord(mockMvc, simple.getPid(), requestBody, SimplePidRecord.CONTENT_TYPE, SimplePidRecord.CONTENT_TYPE);
         SimplePidRecord modified = ApiMockUtils.getJsonMapper().readValue(responseBody, SimplePidRecord.class);
-        assertNotNull(modified.getPairs());
         assertNotNull(modified);
+        assertNotNull(modified.getPairs());
     }
 
     /**

--- a/src/test/java/edu/kit/datamanager/pit/web/SimpleJSONFormatTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/SimpleJSONFormatTest.java
@@ -1,0 +1,53 @@
+package edu.kit.datamanager.pit.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import edu.kit.datamanager.pit.domain.PIDRecord;
+import edu.kit.datamanager.pit.domain.SimplePidRecord;
+
+@AutoConfigureMockMvc
+// JUnit5 + Spring
+@SpringBootTest
+// Set the in-memory implementation
+@TestPropertySource("/test/application-test.properties")
+@ActiveProfiles("test")
+public class SimpleJSONFormatTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.webApplicationContext).build();
+    }
+
+    @Test
+    public void testResolvePid() throws Exception {
+        PIDRecord complexFormat = ApiMockUtils.createSomeRecord(this.mockMvc);
+        assertNotNull(complexFormat);
+
+        SimplePidRecord simpleFormat = ApiMockUtils.resolveSimpleRecord(this.mockMvc, complexFormat.getPid());
+        assertNotNull(simpleFormat);
+        assertNotNull(simpleFormat.getPairs());
+
+        assertEquals(complexFormat.getPid(), simpleFormat.getPid());
+        long complexPairs = complexFormat.getEntries().values().stream().mapToLong(list -> list.size()).sum();
+
+        System.out.println(simpleFormat.getPairs());
+        assertEquals(complexPairs, simpleFormat.getPairs().size());
+    }
+}

--- a/src/test/java/edu/kit/datamanager/pit/web/SimpleJSONFormatTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/SimpleJSONFormatTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
@@ -49,5 +50,61 @@ public class SimpleJSONFormatTest {
 
         System.out.println(simpleFormat.getPairs());
         assertEquals(complexPairs, simpleFormat.getPairs().size());
+    }
+
+    /**
+     * Input: simple json
+     * Accept: simple json
+     * Expect: simple json, HTTP 201
+     */
+    @Test
+    public void testCreatePidFromSimpleAndAcceptSimple() throws Exception {
+        SimplePidRecord input = new SimplePidRecord(ApiMockUtils.getSomePidRecordInstance());
+        String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(input);
+        String responseBody = ApiMockUtils.createRecord(mockMvc, requestBody, SimplePidRecord.CONTENT_TYPE, SimplePidRecord.CONTENT_TYPE);
+        SimplePidRecord sim = ApiMockUtils.getJsonMapper().readValue(responseBody, SimplePidRecord.class);
+        assertNotNull(sim);
+    }
+
+    /**
+     * Input: simple json
+     * Accept: any
+     * Expect: simple json, HTTP 201
+     */
+    @Test
+    public void testCreatePidFromSimpleAndAcceptAll() throws Exception {
+        SimplePidRecord input = new SimplePidRecord(ApiMockUtils.getSomePidRecordInstance());
+        String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(input);
+        String responseBody = ApiMockUtils.createRecord(mockMvc, requestBody, SimplePidRecord.CONTENT_TYPE, MediaType.ALL.toString());
+        SimplePidRecord sim = ApiMockUtils.getJsonMapper().readValue(responseBody, SimplePidRecord.class);
+        assertNotNull(sim);
+    }
+
+    /**
+     * Input: (complex) json
+     * Accept: json
+     * Expect: (complex) json, HTTP 201
+    */
+    @Test
+    public void testCreatePidFromComplexAndAcceptJson() throws Exception {
+        PIDRecord input = ApiMockUtils.getSomePidRecordInstance();
+        String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(input);
+        String responseBody = ApiMockUtils.createRecord(mockMvc, requestBody, MediaType.APPLICATION_JSON.toString(), MediaType.APPLICATION_JSON.toString());
+        SimplePidRecord sim = ApiMockUtils.getJsonMapper().readValue(responseBody, SimplePidRecord.class);
+        assertNotNull(sim);
+    }
+
+    /**
+     * Input: (complex) json
+     * Accept: any
+     * Expect: (complex) json, HTTP 201
+     */
+    @Test
+    public void testCreatePidFromComplexAndAcceptAll() throws Exception {
+        PIDRecord input = ApiMockUtils.getSomePidRecordInstance();
+        String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(input);
+        String responseBody = ApiMockUtils.createRecord(mockMvc, requestBody, MediaType.APPLICATION_JSON.toString(), MediaType.ALL.toString());
+        SimplePidRecord sim = ApiMockUtils.getJsonMapper().readValue(responseBody, SimplePidRecord.class);
+        assertNotNull(sim);
     }
 }

--- a/src/test/java/edu/kit/datamanager/pit/web/SimpleJSONFormatTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/SimpleJSONFormatTest.java
@@ -78,16 +78,16 @@ class SimpleJSONFormatTest {
      * 
      * Input: simple json
      * Accept: any
-     * Expect: simple json, HTTP 201
+     * Expect: (complex) json, HTTP 201
      */
     @Test
     void testCreatePidFromSimpleAndAcceptAll() throws Exception {
         SimplePidRecord input = new SimplePidRecord(ApiMockUtils.getSomePidRecordInstance());
         String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(input);
         String responseBody = ApiMockUtils.createRecord(mockMvc, requestBody, SimplePidRecord.CONTENT_TYPE, MediaType.ALL_VALUE);
-        SimplePidRecord sim = ApiMockUtils.getJsonMapper().readValue(responseBody, SimplePidRecord.class);
-        assertNotNull(sim);
-        assertNotNull(sim.getPairs());
+        PIDRecord modified = ApiMockUtils.getJsonMapper().readValue(responseBody, PIDRecord.class);
+        assertNotNull(modified);
+        assertTrue(modified.getEntries().size() > 0);
     }
 
     /**
@@ -169,7 +169,7 @@ class SimpleJSONFormatTest {
      * 
      * Input: simple json
      * Accept: json
-     * Expect: simple json, HTTP 200
+     * Expect: (complex) json, HTTP 200
      */
     @Test
     void testUpdatePidFromSimpleAndAcceptJson() throws Exception {
@@ -180,9 +180,9 @@ class SimpleJSONFormatTest {
         SimplePidRecord simple = new SimplePidRecord(original);
         String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(simple);
         String responseBody = ApiMockUtils.updateRecord(mockMvc, simple.getPid(), requestBody, SimplePidRecord.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
-        SimplePidRecord modified = ApiMockUtils.getJsonMapper().readValue(responseBody, SimplePidRecord.class);
+        PIDRecord modified = ApiMockUtils.getJsonMapper().readValue(responseBody, PIDRecord.class);
         assertNotNull(modified);
-        assertNotNull(modified.getPairs());
+        assertTrue(modified.getEntries().size() > 0);
     }
 
     /**
@@ -211,7 +211,7 @@ class SimpleJSONFormatTest {
      * 
      * Input: simple json
      * Accept: any
-     * Expect: simple json, HTTP 200
+     * Expect: (complex) json, HTTP 200
      */
     @Test
     void testUpdatePidFromSimpleAndAcceptAll() throws Exception {
@@ -222,9 +222,9 @@ class SimpleJSONFormatTest {
         SimplePidRecord simple = new SimplePidRecord(original);
         String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(simple);
         String responseBody = ApiMockUtils.updateRecord(mockMvc, simple.getPid(), requestBody, SimplePidRecord.CONTENT_TYPE, MediaType.ALL_VALUE);
-        SimplePidRecord modified = ApiMockUtils.getJsonMapper().readValue(responseBody, SimplePidRecord.class);
-        assertNotNull(modified.getPairs());
+        PIDRecord modified = ApiMockUtils.getJsonMapper().readValue(responseBody, PIDRecord.class);
         assertNotNull(modified);
+        assertTrue(modified.getEntries().size() > 0);
     }
 
     /**

--- a/src/test/java/edu/kit/datamanager/pit/web/SimpleJSONFormatTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/SimpleJSONFormatTest.java
@@ -2,6 +2,7 @@ package edu.kit.datamanager.pit.web;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -69,6 +70,7 @@ class SimpleJSONFormatTest {
         String responseBody = ApiMockUtils.createRecord(mockMvc, requestBody, SimplePidRecord.CONTENT_TYPE, SimplePidRecord.CONTENT_TYPE);
         SimplePidRecord sim = ApiMockUtils.getJsonMapper().readValue(responseBody, SimplePidRecord.class);
         assertNotNull(sim);
+        assertNotNull(sim.getPairs());
     }
 
     /**
@@ -85,6 +87,7 @@ class SimpleJSONFormatTest {
         String responseBody = ApiMockUtils.createRecord(mockMvc, requestBody, SimplePidRecord.CONTENT_TYPE, MediaType.ALL_VALUE);
         SimplePidRecord sim = ApiMockUtils.getJsonMapper().readValue(responseBody, SimplePidRecord.class);
         assertNotNull(sim);
+        assertNotNull(sim.getPairs());
     }
 
     /**
@@ -101,6 +104,7 @@ class SimpleJSONFormatTest {
         String responseBody = ApiMockUtils.createRecord(mockMvc, requestBody, MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE);
         SimplePidRecord sim = ApiMockUtils.getJsonMapper().readValue(responseBody, SimplePidRecord.class);
         assertNotNull(sim);
+        assertNotNull(sim.getPairs());
     }
 
     /**
@@ -117,6 +121,7 @@ class SimpleJSONFormatTest {
         String responseBody = ApiMockUtils.createRecord(mockMvc, requestBody, MediaType.APPLICATION_JSON_VALUE, MediaType.ALL_VALUE);
         SimplePidRecord sim = ApiMockUtils.getJsonMapper().readValue(responseBody, SimplePidRecord.class);
         assertNotNull(sim);
+        assertNotNull(sim.getPairs());
     }
 
     /**
@@ -134,8 +139,9 @@ class SimpleJSONFormatTest {
         original.addEntry("21.T11148/b8457812905b83046284", "", "https://example.com/file2");
         String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(original);
         String responseBody = ApiMockUtils.updateRecord(mockMvc, original.getPid(), requestBody, MediaType.APPLICATION_JSON_VALUE, MediaType.ALL_VALUE);
-        PIDRecord sim = ApiMockUtils.getJsonMapper().readValue(responseBody, PIDRecord.class);
-        assertNotNull(sim);
+        PIDRecord modified = ApiMockUtils.getJsonMapper().readValue(responseBody, PIDRecord.class);
+        assertNotNull(modified);
+        assertTrue(modified.getEntries().size() > 0);
     }
 
     /**
@@ -155,6 +161,7 @@ class SimpleJSONFormatTest {
         String responseBody = ApiMockUtils.updateRecord(mockMvc, original.getPid(), requestBody, MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE);
         PIDRecord modified = ApiMockUtils.getJsonMapper().readValue(responseBody, PIDRecord.class);
         assertNotNull(modified);
+        assertTrue(modified.getEntries().size() > 0);
     }
 
     /**
@@ -174,6 +181,7 @@ class SimpleJSONFormatTest {
         String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(simple);
         String responseBody = ApiMockUtils.updateRecord(mockMvc, simple.getPid(), requestBody, SimplePidRecord.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
         SimplePidRecord modified = ApiMockUtils.getJsonMapper().readValue(responseBody, SimplePidRecord.class);
+        assertNotNull(modified.getPairs());
         assertNotNull(modified);
     }
 
@@ -194,6 +202,7 @@ class SimpleJSONFormatTest {
         String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(simple);
         String responseBody = ApiMockUtils.updateRecord(mockMvc, simple.getPid(), requestBody, SimplePidRecord.CONTENT_TYPE, SimplePidRecord.CONTENT_TYPE);
         SimplePidRecord modified = ApiMockUtils.getJsonMapper().readValue(responseBody, SimplePidRecord.class);
+        assertNotNull(modified.getPairs());
         assertNotNull(modified);
     }
 
@@ -214,6 +223,29 @@ class SimpleJSONFormatTest {
         String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(simple);
         String responseBody = ApiMockUtils.updateRecord(mockMvc, simple.getPid(), requestBody, SimplePidRecord.CONTENT_TYPE, MediaType.ALL_VALUE);
         SimplePidRecord modified = ApiMockUtils.getJsonMapper().readValue(responseBody, SimplePidRecord.class);
+        assertNotNull(modified.getPairs());
         assertNotNull(modified);
+    }
+
+    /**
+     * Test: Update PID
+     * 
+     * Input: simple json
+     * Accept: (complex) json
+     * Expect: complex json, HTTP 200
+     */
+    @Test
+    void testUpdatePidFromSimpleAndAcceptComplex() throws Exception {
+        PIDRecord original = ApiMockUtils.createSomeRecord(this.mockMvc);
+        // add digitalObjectLocation, which is a property supported by most profiles.
+        // in future, it would be more reliable to really ask the profile for the pid of this field.
+        original.addEntry("21.T11148/b8457812905b83046284", "", "https://example.com/file2");
+        SimplePidRecord simple = new SimplePidRecord(original);
+        assertNotNull(simple.getPairs());
+        String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(simple);
+        String responseBody = ApiMockUtils.updateRecord(mockMvc, simple.getPid(), requestBody, SimplePidRecord.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+        PIDRecord modified = ApiMockUtils.getJsonMapper().readValue(responseBody, PIDRecord.class);
+        assertNotNull(modified);
+        assertTrue(modified.getEntries().size() > 0);
     }
 }

--- a/src/test/resources/test/application-test.properties
+++ b/src/test/resources/test/application-test.properties
@@ -41,7 +41,7 @@ logging.level.edu.kit: DEBUG
 #logging.level.org.springframework.transaction: TRACE
 logging.level.org.springframework: WARN 
 logging.level.org.springframework.amqp: WARN
-logging.level.com.zaxxer.hikari: DEBUG
+logging.level.com.zaxxer.hikari: WARN
 
 ###################################################################
 ##################  Repository Specific Settings ##################


### PR DESCRIPTION
Second approach (first is #61), with the idea to have a simpler class for database representation. The result is a class which stores two lists of strings. The issues are still comparable to #61, though. This PR is mainly for using the CI to make sure it is not a local issue.

This branch also contains some changes from #77 due to some helpers for the tests being used.