### PR TITLE
Include build info into spring actuator.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ plugins {
     //id "com.github.kt3k.coveralls" version "2.12.0" 
     id "org.owasp.dependencycheck" version "8.0.2"
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
+    // include build and git information via Spring Actuator
+    id "com.gorylenko.gradle-git-properties" version "2.4.1"
 }
 
 lombok {
@@ -182,6 +184,10 @@ jacocoTestReport {
                         ])
                 }))
     }
+}
+
+springBoot {
+    buildInfo()
 }
 
 release {


### PR DESCRIPTION
Fixes #99 

The information is available, e.g., via `/acturator/info` (json).