### PR TITLE
Add search endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The Typed PID Maker enables the creation, maintenance, and validation of PIDs. I
 
 **See also: [Documentation](https://kit-data-manager.github.io/webpage/typed-pid-maker/index.html) | [Configuration details](https://github.com/kit-data-manager/pit-service/blob/master/config/application.properties)**
 
+[TOC]
+
 ## Features
 
 - ✅ Create PIDs containing typed key-value-pairs for easy, fast, and automated decision-making.
@@ -19,6 +21,44 @@ The Typed PID Maker enables the creation, maintenance, and validation of PIDs. I
   - ✅ Search for information stored within PIDs. This includes PIDs you created, updated or resolved at some point.
   - ✅ Supports the [full elastic DSL](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html) (and requires an Elasticsearch 8 instance).
 - ✅ Authentication via [JWT](https://jwt.io/introduction) or [KeyCloak](https://www.keycloak.org/)
+
+### Search example
+
+The search can be executed via the provided swagger interface (default location: <http://localhost:8090/swagger-ui.html>). For example, with the following request body you will get all record information:
+
+```json
+{
+  "query": {
+    "regexp": {
+      "pid": {
+        "value": ".*",
+        "flags": "ALL",
+        "case_insensitive": true
+      }
+    }
+  }
+}
+```
+
+You can also use other http clients, like CURL. A CURL (which may be provided by swagger) request may look like this:
+
+```bash
+curl -X 'POST' \
+  'http://localhost:8090/api/v1/search?page=0&size=20' \
+  -H 'accept: application/hal+json' \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "query": {
+    "regexp": {
+      "pid": {
+        "value": ".*",
+        "flags": "ALL",
+        "case_insensitive": true
+      }
+    }
+  }
+}'
+```
 
 ## How to build
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ The Typed PID Maker enables the creation, maintenance, and validation of PIDs. I
   - ✅ Pagination support
   - ✅ Tabulator.js support
 - ✅ Build & use your own search index
-  - ✅ Search for information stored within PIDs. This includes PIDs you created, updated or resolved at some point. Requires an Elasticsearch instance.
+  - ✅ Search for information stored within PIDs. This includes PIDs you created, updated or resolved at some point.
+  - ✅ Supports the [full elastic DSL](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html) (and requires an Elasticsearch 8 instance).
 - ✅ Authentication via [JWT](https://jwt.io/introduction) or [KeyCloak](https://www.keycloak.org/)
 
 ## How to build

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ The Typed PID Maker enables the creation, maintenance, and validation of PIDs. I
 - ✅ Maintain the information within these PIDs.
 - ✅ Validate PIDs.
 - ✅ Resolve PIDs.
-- ✅ Store the created PIDs in your database.
+- ✅ Store the created PIDs in your database and query them.
   - ✅ Pagination support
   - ✅ Tabulator.js support
+- ✅ Build & use your own search index
+  - ✅ Search for information stored within PIDs. This includes PIDs you created, updated or resolved at some point. Requires an Elasticsearch instance.
 - ✅ Authentication via [JWT](https://jwt.io/introduction) or [KeyCloak](https://www.keycloak.org/)
 
 ## How to build

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     // Spring boot & dependency management:
     // https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/htmlsingle/
-    id 'org.springframework.boot' version '2.7.9'
+    id 'org.springframework.boot' version '2.7.10'
     // https://docs.spring.io/dependency-management-plugin/docs/current-SNAPSHOT/reference/html/
     id "io.spring.dependency-management" version "1.1.0"
     // Lombok generates getter and setter and more. https://projectlombok.org/

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
     // Adds coveralls task for CI to send results to the coveralls service.
     id "com.github.kt3k.coveralls" version "2.12.2"
     //id "com.github.kt3k.coveralls" version "2.12.0" 
-    id "org.owasp.dependencycheck" version "8.1.2"
+    id "org.owasp.dependencycheck" version "8.2.1"
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
     // include build and git information via Spring Actuator
     id "com.gorylenko.gradle-git-properties" version "2.4.1"

--- a/build.gradle
+++ b/build.gradle
@@ -57,8 +57,8 @@ ext {
 dependencies {
     // Due to the spring boot gradle plugin, we can omit versions in org.springframework.*
     // dependencies. It will automatically choose the fitting ones.
-    implementation("edu.kit.datamanager:service-base:1.1.0")
-    implementation("edu.kit.datamanager:repo-core:1.1.1")
+    implementation("edu.kit.datamanager:service-base:1.1.1")
+    implementation("edu.kit.datamanager:repo-core:1.1.2")
     // com.google.common, LoadingCache
     implementation("com.google.guava:guava:31.1-jre")
     // Required by Spring/Javers at runtime

--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,8 @@ dependencies {
     implementation "org.springdoc:springdoc-openapi-ui:${springDocVersion}"
     implementation "org.springdoc:springdoc-openapi-data-rest:${springDocVersion}"
     implementation "org.springdoc:springdoc-openapi-webmvc-core:${springDocVersion}"
+    // spring + elasticsearch communication
+    implementation "org.springframework.data:spring-data-elasticsearch"
 
     // More flexibility when (de-)serializing json:
     //implementation("com.monitorjbl:spring-json-view:1.1.0")

--- a/config/application.properties
+++ b/config/application.properties
@@ -162,6 +162,10 @@ pit.security.allowedOriginPattern: http*://localhost:[*]
 # But the service will also use this database to store known PIDs.
 # This can be used as a backup or documentation of all PIDs.
 # The following properties can (and should) be set.
+
+# When to store PIDs in the local database ("known PIDs")
+pit.storage.strategy: keep-resolved-and-modified
+#pit.storage.strategy: keep-resolved
 # The driver detemins the database system to start. Other drivers are untested, but may work.
 spring.datasource.driver-class-name: org.h2.Driver
 # Next, please choose a location for the database file on your file system.

--- a/config/application.properties
+++ b/config/application.properties
@@ -86,8 +86,8 @@ spring.autoconfigure.exclude=org.keycloak.adapters.springboot.KeycloakAutoConfig
 ############################################
 
 # enables search endpoint at /api/v1/search
-repo.search.enabled: true
-management.health.elasticsearch.enabled: true
+repo.search.enabled: false
+management.health.elasticsearch.enabled: false
 repo.search.url: http://localhost:9200
 repo.search.index: *
 

--- a/config/application.properties
+++ b/config/application.properties
@@ -20,7 +20,7 @@ server.compression.enabled: false
 spring.servlet.multipart.max-file-size: 100MB
 spring.servlet.multipart.max-request-size: 100MB
    
-# Spring Management Endpoint Settings. By default, the health endpoint will be 
+# *Generic* Spring Management Endpoint Settings. By default, the health endpoint will be 
 # enabled to apply service monitoring including detailed information. 
 # Furthermore, all endpoints will be exposed to external access. If this is not desired, 
 # just comment the property 'management.endpoints.web.exposure.include' in order to only 
@@ -80,6 +80,16 @@ spring.autoconfigure.exclude=org.keycloak.adapters.springboot.KeycloakAutoConfig
 #keycloak.realm = myrealm
 #keycloak.auth-server-url = http://localhost:8080/auth
 #keycloak.resource = keycloak-angular
+
+############################################
+### Elastic Indexing and search endpoint ###
+############################################
+
+# enables search endpoint at /api/v1/search
+repo.search.enabled: true
+management.health.elasticsearch.enabled: true
+repo.search.url: http://localhost:9200
+repo.search.index: *
 
 #################
 ### Messaging ###

--- a/config/application.properties
+++ b/config/application.properties
@@ -83,6 +83,7 @@ spring.autoconfigure.exclude=org.keycloak.adapters.springboot.KeycloakAutoConfig
 
 ############################################
 ### Elastic Indexing and search endpoint ###
+######## (requires Elasticsearch 8) ########
 ############################################
 
 # enables search endpoint at /api/v1/search

--- a/docker/test_docker.sh
+++ b/docker/test_docker.sh
@@ -23,7 +23,7 @@ fi
 echo -n "run container: "
 docker run -p 8090:8090 --detach --name $container $tag
 # give the application and container some time:
-sleep 20 # seconds
+sleep 30 # seconds
 
 #####################################
 ### tests ###########################

--- a/src/main/java/edu/kit/datamanager/pit/configuration/ElasticConfiguration.java
+++ b/src/main/java/edu/kit/datamanager/pit/configuration/ElasticConfiguration.java
@@ -30,10 +30,6 @@ import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 import org.springframework.http.HttpHeaders;
 
-/**
- *
- * @author jejkal
- */
 @Configuration
 @EnableElasticsearchRepositories(basePackages = "edu.kit.datamanager.repo")
 @ComponentScan(basePackages = {"edu.kit.datamanager"})

--- a/src/main/java/edu/kit/datamanager/pit/configuration/ElasticConfiguration.java
+++ b/src/main/java/edu/kit/datamanager/pit/configuration/ElasticConfiguration.java
@@ -1,0 +1,70 @@
+package edu.kit.datamanager.pit.configuration;
+
+/*
+ * Copyright 2022 Karlsruhe Institute of Technology.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import edu.kit.datamanager.configuration.SearchConfiguration;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.RestClients;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+import org.springframework.http.HttpHeaders;
+
+/**
+ *
+ * @author jejkal
+ */
+@Configuration
+@EnableElasticsearchRepositories(basePackages = "edu.kit.datamanager.repo")
+@ComponentScan(basePackages = {"edu.kit.datamanager"})
+@ConditionalOnProperty(prefix = "repo.search", name = "enabled", havingValue = "true")
+public class ElasticConfiguration {
+
+    @Autowired
+    private SearchConfiguration searchConfiguration;
+
+    @Bean
+    public RestHighLevelClient client() {
+        //required for compatibility to Elastic 8.X ... might not work and should be removed with spring-boot 3.X
+        HttpHeaders compatibilityHeaders = new HttpHeaders();
+        compatibilityHeaders.add("Accept", "application/vnd.elasticsearch+json;compatible-with=7");
+        compatibilityHeaders.add("Content-Type", "application/vnd.elasticsearch+json;compatible-with=7");
+
+        String indexUrl = searchConfiguration.getUrl().toString();
+        String hostnamePort = indexUrl.substring(indexUrl.indexOf("//") + 2);
+
+        ClientConfiguration clientConfiguration
+                = ClientConfiguration.builder()
+                        .connectedTo(hostnamePort)
+                        .withDefaultHeaders(compatibilityHeaders)
+                        .build();
+
+        return RestClients.create(clientConfiguration).rest();
+    }
+
+    @Bean
+    public ElasticsearchOperations elasticsearchTemplate() {
+        return new ElasticsearchRestTemplate(client());
+    }
+
+}

--- a/src/main/java/edu/kit/datamanager/pit/domain/Operations.java
+++ b/src/main/java/edu/kit/datamanager/pit/domain/Operations.java
@@ -59,8 +59,10 @@ public class Operations {
         // we need to resolve types without streams to forward possible exceptions
         Collection<TypeDefinition> types = new ArrayList<>();
         for (String attributePid : pidRecord.getPropertyIdentifiers()) {
-            TypeDefinition type = this.typingService.describeType(attributePid);
-            types.add(type);
+            if (this.typingService.isIdentifierRegistered(attributePid)) {
+                TypeDefinition type = this.typingService.describeType(attributePid);
+                types.add(type);
+            }
         }
 
         /*
@@ -109,8 +111,10 @@ public class Operations {
         // we need to resolve types without streams to forward possible exceptions
         Collection<TypeDefinition> types = new ArrayList<>();
         for (String attributePid : pidRecord.getPropertyIdentifiers()) {
-            TypeDefinition type = this.typingService.describeType(attributePid);
-            types.add(type);
+            if (this.typingService.isIdentifierRegistered(attributePid)) {
+                TypeDefinition type = this.typingService.describeType(attributePid);
+                types.add(type);
+            }
         }
 
         /*

--- a/src/main/java/edu/kit/datamanager/pit/domain/Operations.java
+++ b/src/main/java/edu/kit/datamanager/pit/domain/Operations.java
@@ -1,0 +1,151 @@
+package edu.kit.datamanager.pit.domain;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import edu.kit.datamanager.pit.pitservice.ITypingService;
+
+/**
+ * Simple operations on PID records.
+ * 
+ * Caches results e.g. for type queries
+ */
+public class Operations {
+
+    private static final String[] KNOWN_DATE_CREATED = {
+        "21.T11148/29f92bd203dd3eaa5a1f",
+        "21.T11148/aafd5fb4c7222e2d950a"
+    };
+
+    private static final String[] KNOWN_DATE_MODIFIED = {
+        "21.T11148/397d831aa3a9d18eb52c"
+    };
+
+    @Autowired
+    private static ITypingService pit;
+
+    private Operations() {
+        // static class
+    }
+
+    public static Optional<Date> findDateCreated(PIDRecord pidRecord) throws IOException {
+        /* try known types */
+        List<String> knownDateTypes = Arrays.asList(Operations.KNOWN_DATE_CREATED);
+        Optional<Date> date = knownDateTypes
+            .stream()
+            .map(pidRecord::getPropertyValues)
+            .map(Arrays::asList)
+            .flatMap(List<String>::stream)
+            .map(Operations::extractDate)
+            .filter(Optional<Date>::isPresent)
+            .map(Optional<Date>::get)
+            .sorted(Comparator.comparingLong(Date::getTime))
+            .findFirst();
+        if (date.isPresent()) {
+            return date;
+        }
+
+        /* TODO try to find types extending or relating otherwise to known types
+         *      (currently not supported by our TypeDefinition) */
+        // we need to resolve types without streams to forward possible exceptions
+        Collection<TypeDefinition> types = new ArrayList<>();
+        for (String attributePid : pidRecord.getPropertyIdentifiers()) {
+            TypeDefinition type = pit.describeType(attributePid);
+            types.add(type);
+        }
+
+        /*
+         * as a last fallback, try find types with human readable names containing
+         * "dateCreated" or "createdAt" or "creationDate".
+         * 
+         * This can be removed as soon as we have some default FAIR DO types new type
+         * definitions can refer to (e.g. "extend" them or declare the same meaning as
+         * our known types, see above)
+         */
+        return types
+            .stream()
+            .filter(type -> 
+                type.getName().equals("dateCreated")
+                || type.getName().equals("createdAt")
+                || type.getName().equals("creationDate"))
+            .map(type -> pidRecord.getPropertyValues(type.getIdentifier()))
+            .map(values -> Arrays.asList(values))
+            .flatMap(List<String>::stream)
+            .map(Operations::extractDate)
+            .filter(Optional<Date>::isPresent)
+            .map(Optional<Date>::get)
+            .sorted(Comparator.comparingLong(Date::getTime))
+            .findFirst();
+    }
+
+    public static Optional<Date> findDateModified(PIDRecord pidRecord) throws IOException {
+        /* try known types */
+        List<String> knownDateTypes = Arrays.asList(Operations.KNOWN_DATE_MODIFIED);
+        Optional<Date> date = knownDateTypes
+            .stream()
+            .map(pidRecord::getPropertyValues)
+            .map(Arrays::asList)
+            .flatMap(List<String>::stream)
+            .map(Operations::extractDate)
+            .filter(Optional<Date>::isPresent)
+            .map(Optional<Date>::get)
+            .sorted(Comparator.comparingLong(Date::getTime))
+            .findFirst();
+        if (date.isPresent()) {
+            return date;
+        }
+
+        /* TODO try to find types extending or relating otherwise to known types
+         *      (currently not supported by our TypeDefinition) */
+        // we need to resolve types without streams to forward possible exceptions
+        Collection<TypeDefinition> types = new ArrayList<>();
+        for (String attributePid : pidRecord.getPropertyIdentifiers()) {
+            TypeDefinition type = pit.describeType(attributePid);
+            types.add(type);
+        }
+
+        /*
+         * as a last fallback, try find types with human readable names containing
+         * "dateModified" or "lastModified" or "modificationDate".
+         * 
+         * This can be removed as soon as we have some default FAIR DO types new type
+         * definitions can refer to (e.g. "extend" them or declare the same meaning as
+         * our known types, see above)
+         */
+        return types
+            .stream()
+            .filter(type -> 
+                type.getName().equals("dateModified")
+                || type.getName().equals("lastModified")
+                || type.getName().equals("modificationDate"))
+            .map(type -> pidRecord.getPropertyValues(type.getIdentifier()))
+            .map(values -> Arrays.asList(values))
+            .flatMap(List<String>::stream)
+            .map(Operations::extractDate)
+            .filter(Optional<Date>::isPresent)
+            .map(Optional<Date>::get)
+            .sorted(Comparator.comparingLong(Date::getTime))
+            .findFirst();
+    }
+
+    protected static Optional<Date> extractDate(String dateString) {
+        DateTimeFormatter dateFormatter = ISODateTimeFormat.dateTime();
+        try {
+            DateTime dateTime = dateFormatter.parseDateTime(dateString);
+            return Optional.of(dateTime.toDate());
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/edu/kit/datamanager/pit/domain/PIDRecord.java
+++ b/src/main/java/edu/kit/datamanager/pit/domain/PIDRecord.java
@@ -179,7 +179,7 @@ public class PIDRecord {
     public String getPropertyValue(String propertyIdentifier) {
         List<PIDRecordEntry> entry = entries.get(propertyIdentifier);
         if (entry == null) {
-            throw new IllegalArgumentException("Property identifier not listed in this record: " + propertyIdentifier);
+            return "";
         }
         return entry.get(0).getValue();
     }
@@ -193,7 +193,7 @@ public class PIDRecord {
     public String[] getPropertyValues(String propertyIdentifier) {
         List<PIDRecordEntry> entry = entries.get(propertyIdentifier);
         if (entry == null) {
-            throw new IllegalArgumentException("Property identifier not listed in this record: " + propertyIdentifier);
+            return new String[]{};
         }
 
         List<String> values = new ArrayList<>();

--- a/src/main/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticRepository.java
+++ b/src/main/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticRepository.java
@@ -19,15 +19,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
-import org.springframework.stereotype.Repository;
 
 /**
  * Elastic repository for indexing PID records.
  */
-@Repository
 @ConditionalOnProperty(prefix = "repo.search", name = "enabled", havingValue = "true")
 public interface PidRecordElasticRepository extends ElasticsearchRepository<PidRecordElasticWrapper, String> {
 
-    Page<PidRecordElasticWrapper> findById(String id, Pageable pageable);
+    Page<PidRecordElasticWrapper> findByPid(String pid, Pageable pageable);
 
 }

--- a/src/main/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticRepository.java
+++ b/src/main/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticRepository.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Karlsruhe Institute of Technology.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.kit.datamanager.pit.elasticsearch;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Elastic repository for indexing PID records.
+ */
+@Repository
+@ConditionalOnProperty(prefix = "repo.search", name = "enabled", havingValue = "true")
+public interface PidRecordElasticRepository extends ElasticsearchRepository<PidRecordElasticWrapper, String> {
+
+    Page<PidRecordElasticWrapper> findById(String id, Pageable pageable);
+
+}

--- a/src/main/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticWrapper.java
+++ b/src/main/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticWrapper.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Karlsruhe Institute of Technology.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.kit.datamanager.pit.elasticsearch;
+
+import edu.kit.datamanager.pit.domain.PIDRecord;
+import edu.kit.datamanager.pit.pidsystem.impl.local.PidDatabaseObject;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.persistence.ElementCollection;
+import javax.persistence.FetchType;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+@Document(indexName = "typedpidmaker")
+public class PidRecordElasticWrapper {
+
+    @Id
+    private String pid;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    private Map<String, ArrayList<String>> attributes = new HashMap<>();
+
+    @Field(type = FieldType.Date, format = DateFormat.basic_date_time)
+    private Date created;
+
+    @Field(type = FieldType.Date, format = DateFormat.basic_date_time)
+    private Date lastUpdate;
+
+    /** For hibernate */
+    public PidRecordElasticWrapper() {}
+
+    public PidRecordElasticWrapper(PIDRecord pidRecord) {
+        pid = pidRecord.getPid();
+        PidDatabaseObject simple = new PidDatabaseObject(pidRecord);
+        this.attributes = simple.getEntries();
+
+        // TODO set dates
+        //pidRecord.getDates().stream().filter(d -> (DATE_TYPE.CREATED.equals(d.getType()))).forEachOrdered(d -> {
+        //    created = Date.from(d.getValue());
+        //});
+        //lastUpdate = Date.from(Instant.now());
+    }
+}

--- a/src/main/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticWrapper.java
+++ b/src/main/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticWrapper.java
@@ -49,17 +49,14 @@ public class PidRecordElasticWrapper {
     @Field(type = FieldType.Date, format = DateFormat.basic_date_time)
     private Date lastUpdate;
 
-    /** For hibernate */
-    public PidRecordElasticWrapper() {}
-
-    public PidRecordElasticWrapper(PIDRecord pidRecord) {
+    public PidRecordElasticWrapper(PIDRecord pidRecord, Operations dateOperations) {
         pid = pidRecord.getPid();
         PidDatabaseObject simple = new PidDatabaseObject(pidRecord);
         this.attributes = simple.getEntries();
 
         try {
-            this.created = Operations.findDateCreated(pidRecord).orElse(null);
-            this.lastUpdate = Operations.findDateModified(pidRecord).orElse(null);
+            this.created = dateOperations.findDateCreated(pidRecord).orElse(null);
+            this.lastUpdate = dateOperations.findDateModified(pidRecord).orElse(null);
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/main/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticWrapper.java
+++ b/src/main/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticWrapper.java
@@ -15,9 +15,11 @@
  */
 package edu.kit.datamanager.pit.elasticsearch;
 
+import edu.kit.datamanager.pit.domain.Operations;
 import edu.kit.datamanager.pit.domain.PIDRecord;
 import edu.kit.datamanager.pit.pidsystem.impl.local.PidDatabaseObject;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -55,10 +57,11 @@ public class PidRecordElasticWrapper {
         PidDatabaseObject simple = new PidDatabaseObject(pidRecord);
         this.attributes = simple.getEntries();
 
-        // TODO set dates
-        //pidRecord.getDates().stream().filter(d -> (DATE_TYPE.CREATED.equals(d.getType()))).forEachOrdered(d -> {
-        //    created = Date.from(d.getValue());
-        //});
-        //lastUpdate = Date.from(Instant.now());
+        try {
+            this.created = Operations.findDateCreated(pidRecord).orElse(null);
+            this.lastUpdate = Operations.findDateModified(pidRecord).orElse(null);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/src/main/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticWrapper.java
+++ b/src/main/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticWrapper.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.persistence.ElementCollection;
@@ -49,10 +50,14 @@ public class PidRecordElasticWrapper {
     @Field(type = FieldType.Date, format = DateFormat.basic_date_time)
     private Date lastUpdate;
 
+    @Field(type = FieldType.Text)
+    private List<String> read = new ArrayList<>();
+
     public PidRecordElasticWrapper(PIDRecord pidRecord, Operations dateOperations) {
         pid = pidRecord.getPid();
         PidDatabaseObject simple = new PidDatabaseObject(pidRecord);
         this.attributes = simple.getEntries();
+        this.read.add("anonymousUser");
 
         try {
             this.created = dateOperations.findDateCreated(pidRecord).orElse(null);

--- a/src/main/java/edu/kit/datamanager/pit/pidsystem/IIdentifierSystem.java
+++ b/src/main/java/edu/kit/datamanager/pit/pidsystem/IIdentifierSystem.java
@@ -24,8 +24,8 @@ public interface IIdentifierSystem {
      * Queries all properties from the given PID, independent of types.
      *
      * @param pid
-     * @return a PID information record with property identifiers mapping to
-     * values. The property names will be empty strings. Contains all property
+     * @return a PID information record with its PID and attribute-value-pairs.
+     * The property names will be empty strings. Contains all property
      * values present in the record of the given PID. If the pid is not
      * registered, the method returns null.
      * @throws IOException

--- a/src/main/java/edu/kit/datamanager/pit/pidsystem/impl/local/PidDatabaseObject.java
+++ b/src/main/java/edu/kit/datamanager/pit/pidsystem/impl/local/PidDatabaseObject.java
@@ -36,7 +36,7 @@ public class PidDatabaseObject {
     private Map<String, ArrayList<String>> entries = new HashMap<>();
 
     /** For hibernate */
-    PidDatabaseObject() {}
+    public PidDatabaseObject() {}
 
     /** Protected constructor for testing purposes. */
     protected PidDatabaseObject(String pid, String hiddenIndentifier) {
@@ -46,7 +46,7 @@ public class PidDatabaseObject {
         this.entries.put(hiddenIndentifier, values);
     }
 
-    PidDatabaseObject(PIDRecord other) {
+    public PidDatabaseObject(PIDRecord other) {
         this.pid = other.getPid();
 
         other

--- a/src/main/java/edu/kit/datamanager/pit/pitservice/ITypingService.java
+++ b/src/main/java/edu/kit/datamanager/pit/pitservice/ITypingService.java
@@ -1,6 +1,7 @@
 package edu.kit.datamanager.pit.pitservice;
 
 import edu.kit.datamanager.pit.common.InconsistentRecordsException;
+import edu.kit.datamanager.pit.domain.Operations;
 import edu.kit.datamanager.pit.domain.PIDRecord;
 import edu.kit.datamanager.pit.domain.TypeDefinition;
 import java.io.IOException;
@@ -113,4 +114,13 @@ public interface ITypingService extends IIdentifierSystem {
 //   * @throws IOException
 //   */
 //  public EntityClass determineEntityClass(String identifier) throws IOException;
+
+    /**
+     * Returns an operations instance, configured with this typingService.
+     * 
+     * Convenience method for `new Operations(typingService)`.
+     * 
+     * @return an operation instance.
+     */
+    public Operations getOperations();
 }

--- a/src/main/java/edu/kit/datamanager/pit/pitservice/impl/TypingService.java
+++ b/src/main/java/edu/kit/datamanager/pit/pitservice/impl/TypingService.java
@@ -13,6 +13,7 @@ import edu.kit.datamanager.pit.pidsystem.IIdentifierSystem;
 import edu.kit.datamanager.pit.typeregistry.ITypeRegistry;
 import edu.kit.datamanager.pit.pitservice.ITypingService;
 import edu.kit.datamanager.pit.common.InconsistentRecordsException;
+import edu.kit.datamanager.pit.domain.Operations;
 import edu.kit.datamanager.pit.domain.PIDRecord;
 import edu.kit.datamanager.pit.domain.TypeDefinition;
 import java.util.concurrent.ExecutionException;
@@ -275,6 +276,11 @@ public class TypingService implements ITypingService {
     @Override
     public boolean updatePID(PIDRecord record) throws IOException {
         return this.identifierSystem.updatePID(record);
+    }
+
+    @Override
+    public Operations getOperations()  {
+        return new Operations(this);
     }
 
 }

--- a/src/main/java/edu/kit/datamanager/pit/pitservice/impl/TypingService.java
+++ b/src/main/java/edu/kit/datamanager/pit/pitservice/impl/TypingService.java
@@ -124,11 +124,13 @@ public class TypingService implements ITypingService {
     @Override
     public PIDRecord queryAllProperties(String pid) throws IOException {
         LOG.trace("Performing queryAllProperties({}).", pid);
-        PIDRecord record = identifierSystem.queryAllProperties(pid);
-        if (record == null) {
+        PIDRecord pidRecord = identifierSystem.queryAllProperties(pid);
+        if (pidRecord == null) {
             throw new PidNotFoundException(pid);
         }
-        return record;
+        // ensure the PID is always contained
+        pidRecord.setPid(pid);
+        return pidRecord;
     }
 
     @Override

--- a/src/main/java/edu/kit/datamanager/pit/web/impl/TypingRESTResourceImpl.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/impl/TypingRESTResourceImpl.java
@@ -583,7 +583,9 @@ public class TypingRESTResourceImpl implements ITypingRestResource {
 
     private void saveToElastic(PIDRecord rec) {
         this.elastic.ifPresent(
-            database -> database.save(new PidRecordElasticWrapper(rec))
+            database -> database.save(
+                new PidRecordElasticWrapper(rec, typingService.getOperations())
+            )
         );
     }
 

--- a/src/main/java/edu/kit/datamanager/pit/web/impl/TypingRESTResourceImpl.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/impl/TypingRESTResourceImpl.java
@@ -17,6 +17,8 @@ import edu.kit.datamanager.pit.common.RecordValidationException;
 import edu.kit.datamanager.pit.domain.PIDRecord;
 import edu.kit.datamanager.pit.domain.SimplePidRecord;
 import edu.kit.datamanager.pit.domain.TypeDefinition;
+import edu.kit.datamanager.pit.elasticsearch.PidRecordElasticRepository;
+import edu.kit.datamanager.pit.elasticsearch.PidRecordElasticWrapper;
 import edu.kit.datamanager.pit.pidlog.KnownPid;
 import edu.kit.datamanager.pit.pidlog.KnownPidsDao;
 import edu.kit.datamanager.pit.pitservice.ITypingService;
@@ -331,6 +333,9 @@ public class TypingRESTResourceImpl implements ITypingRestResource {
     @Autowired
     private KnownPidsDao localPidStorage;
 
+    @Autowired
+    private Optional<PidRecordElasticRepository> elastic;
+
     public TypingRESTResourceImpl() {
         super();
     }
@@ -341,9 +346,20 @@ public class TypingRESTResourceImpl implements ITypingRestResource {
             final HttpServletResponse response,
             final UriComponentsBuilder uriBuilder) throws IOException {
         LOG.trace("Performing isPidMatchingProfile({}).", identifier);
+
         String profileId = getContentPathFromRequest("profile", request);
-        LOG.trace("Validating PID record with identifier {} against profile with identifier {} from request path.",
-                identifier, profileId);
+        LOG.trace(
+                "Validating PID record with identifier {} against profile with identifier {} from request path.",
+                identifier,
+                profileId
+        );
+
+        PIDRecord pidRecord = this.typingService.queryAllProperties(identifier);
+        this.saveToElastic(pidRecord);
+        if (this.applicationProps.getStorageStrategy().storesResolved()) {
+            this.storeLocally(identifier, false);
+        }
+
         if (typingService.conformsToType(identifier, profileId)) {
             LOG.trace("PID record with identifier {} is matching profile with identifier {}.", identifier, profileId);
             return ResponseEntity.status(200).build();
@@ -375,6 +391,10 @@ public class TypingRESTResourceImpl implements ITypingRestResource {
                 typeId);
         if (TypeValidationUtils.isValid(record, typeDef)) {
             LOG.trace("PID record with identifier {} is matching type with identifier {}.", identifier, typeId);
+            this.saveToElastic(record);
+            if (this.applicationProps.getStorageStrategy().storesResolved()) {
+                this.storeLocally(identifier, false);
+            }
             return ResponseEntity.ok().build();
         }
 
@@ -434,6 +454,7 @@ public class TypingRESTResourceImpl implements ITypingRestResource {
             } catch (Exception e) {
                 LOG.error("Could not notify messaging service about the following message: {}", message.toString());
             }
+            this.saveToElastic(record);
             return ResponseEntity.status(HttpStatus.CREATED.value()).body(record);
         } else if (missingProfile) {
             // validation failed and profile is missing (this must therefore be the reason)
@@ -488,6 +509,7 @@ public class TypingRESTResourceImpl implements ITypingRestResource {
                     AuthenticationHelper.getPrincipal(),
                     ControllerUtils.getLocalHostname());
             this.messagingService.send(message);
+            this.saveToElastic(record);
             return ResponseEntity.ok().body(record);
         } else {
             throw new PidNotFoundException(pid);
@@ -502,11 +524,13 @@ public class TypingRESTResourceImpl implements ITypingRestResource {
         String pid = getContentPathFromRequest("pid", request);
         LOG.trace("Obtained PID {} from request.", pid);
 
-        if (typingService.isIdentifierRegistered(pid)) {
+        PIDRecord pidRecord = typingService.queryAllProperties(pid);
+        if (pidRecord != null) {
             LOG.trace("PID successfully checked.");
             if (applicationProps.getStorageStrategy().storesResolved()) {
-                storeLocally(pid, false);
+                this.storeLocally(pid, false);
             }
+            this.saveToElastic(pidRecord);
             return ResponseEntity.ok().body("PID is registered.");
         } else {
             LOG.error("PID {} not found at configured identifier system.", pid);
@@ -553,7 +577,14 @@ public class TypingRESTResourceImpl implements ITypingRestResource {
         if (applicationProps.getStorageStrategy().storesResolved()) {
             storeLocally(pid, false);
         }
+        this.saveToElastic(rec);
         return ResponseEntity.ok().body(rec);
+    }
+
+    private void saveToElastic(PIDRecord rec) {
+        this.elastic.ifPresent(
+            database -> database.save(new PidRecordElasticWrapper(rec))
+        );
     }
 
     @Override

--- a/src/test/java/edu/kit/datamanager/pit/domain/OperationsTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/domain/OperationsTest.java
@@ -1,5 +1,6 @@
 package edu.kit.datamanager.pit.domain;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -7,10 +8,12 @@ import java.util.Date;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 
+import edu.kit.datamanager.pit.pitservice.ITypingService;
 import edu.kit.datamanager.pit.web.ApiMockUtils;
 
 // JUnit5 + Spring
@@ -19,24 +22,40 @@ import edu.kit.datamanager.pit.web.ApiMockUtils;
 @TestPropertySource("/test/application-test.properties")
 @ActiveProfiles("test")
 public class OperationsTest {
+
+    @Autowired
+    private ITypingService typingService;
+
+    @Test
+    void testSpringSetup() {
+        assertNotNull(typingService);
+    }
+
     @Test
     void testFindDateCreated() throws IOException {
         PIDRecord pidRecord = ApiMockUtils.getSomePidRecordInstance();
-        Optional<Date> date = Operations.findDateCreated(pidRecord);
+        Optional<Date> date = typingService.getOperations().findDateCreated(pidRecord);
         assertTrue(date.isPresent());
     }
 
     @Test
     void testFindDateModified() throws IOException {
         PIDRecord pidRecord = ApiMockUtils.getSomePidRecordInstance();
-        Optional<Date> date = Operations.findDateModified(pidRecord);
+        Optional<Date> date = typingService.getOperations().findDateModified(pidRecord);
         assertTrue(date.isPresent());
     }
 
     @Test
     void testExtractDate() {
         String dateStr = "2021-12-21T17:36:09.541+00:00";
-        Optional<Date> date = Operations.extractDate(dateStr);
+        Optional<Date> date = typingService.getOperations().extractDate(dateStr);
         assertTrue(date.isPresent());
+    }
+
+    @Test
+    void testExtractDateFail() {
+        String dateStr = "asdf";
+        Optional<Date> date = typingService.getOperations().extractDate(dateStr);
+        assertTrue(date.isEmpty());
     }
 }

--- a/src/test/java/edu/kit/datamanager/pit/domain/OperationsTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/domain/OperationsTest.java
@@ -1,0 +1,42 @@
+package edu.kit.datamanager.pit.domain;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import edu.kit.datamanager.pit.web.ApiMockUtils;
+
+// JUnit5 + Spring
+@SpringBootTest
+// Set the in-memory implementation
+@TestPropertySource("/test/application-test.properties")
+@ActiveProfiles("test")
+public class OperationsTest {
+    @Test
+    void testFindDateCreated() throws IOException {
+        PIDRecord pidRecord = ApiMockUtils.getSomePidRecordInstance();
+        Optional<Date> date = Operations.findDateCreated(pidRecord);
+        assertTrue(date.isPresent());
+    }
+
+    @Test
+    void testFindDateModified() throws IOException {
+        PIDRecord pidRecord = ApiMockUtils.getSomePidRecordInstance();
+        Optional<Date> date = Operations.findDateModified(pidRecord);
+        assertTrue(date.isPresent());
+    }
+
+    @Test
+    void testExtractDate() {
+        String dateStr = "2021-12-21T17:36:09.541+00:00";
+        Optional<Date> date = Operations.extractDate(dateStr);
+        assertTrue(date.isPresent());
+    }
+}

--- a/src/test/java/edu/kit/datamanager/pit/domain/OperationsTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/domain/OperationsTest.java
@@ -23,6 +23,8 @@ import edu.kit.datamanager.pit.web.ApiMockUtils;
 @ActiveProfiles("test")
 public class OperationsTest {
 
+    public static final String VALID_DATE = "2021-12-21T17:36:09.541+00:00";
+
     @Autowired
     private ITypingService typingService;
 
@@ -39,6 +41,16 @@ public class OperationsTest {
     }
 
     @Test
+    void testFindDateCreatedFail() throws IOException {
+        PIDRecord pidRecord = new PIDRecord();
+        // should fail because the type is not semantically recognizable as a date
+        // (because it is not a registered type)
+        pidRecord.addEntry("non-registered-creation-date", "", VALID_DATE);
+        Optional<Date> date = typingService.getOperations().findDateCreated(pidRecord);
+        assertTrue(date.isEmpty());
+    }
+
+    @Test
     void testFindDateModified() throws IOException {
         PIDRecord pidRecord = ApiMockUtils.getSomePidRecordInstance();
         Optional<Date> date = typingService.getOperations().findDateModified(pidRecord);
@@ -46,9 +58,18 @@ public class OperationsTest {
     }
 
     @Test
+    void testFindDateModifiedFail() throws IOException {
+        PIDRecord pidRecord = new PIDRecord();
+        // should fail because the type is not semantically recognizable as a date
+        // (because it is not a registered type)
+        pidRecord.addEntry("non-registered-creation-date", "", VALID_DATE);
+        Optional<Date> date = typingService.getOperations().findDateModified(pidRecord);
+        assertTrue(date.isEmpty());
+    }
+
+    @Test
     void testExtractDate() {
-        String dateStr = "2021-12-21T17:36:09.541+00:00";
-        Optional<Date> date = typingService.getOperations().extractDate(dateStr);
+        Optional<Date> date = typingService.getOperations().extractDate(VALID_DATE);
         assertTrue(date.isPresent());
     }
 

--- a/src/test/java/edu/kit/datamanager/pit/domain/OperationsTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/domain/OperationsTest.java
@@ -24,9 +24,11 @@ import edu.kit.datamanager.pit.web.ApiMockUtils;
 public class OperationsTest {
 
     public static final String VALID_DATE = "2021-12-21T17:36:09.541+00:00";
+    public static final String TYPE_PROFILE = "21.T11148/076759916209e5d62bd5";
 
     @Autowired
     private ITypingService typingService;
+
 
     @Test
     void testSpringSetup() {
@@ -41,11 +43,21 @@ public class OperationsTest {
     }
 
     @Test
-    void testFindDateCreatedFail() throws IOException {
+    void testFindDateCreatedFailUnregistered() throws IOException {
         PIDRecord pidRecord = new PIDRecord();
         // should fail because the type is not semantically recognizable as a date
         // (because it is not a registered type)
         pidRecord.addEntry("non-registered-creation-date", "", VALID_DATE);
+        Optional<Date> date = typingService.getOperations().findDateCreated(pidRecord);
+        assertTrue(date.isEmpty());
+    }
+
+    @Test
+    void testFindDateCreatedFailRegistered() throws IOException {
+        PIDRecord pidRecord = new PIDRecord();
+        // should fail because the type is not semantically recognizable as a date
+        // (although it is a resolveable type)
+        pidRecord.addEntry(TYPE_PROFILE, "", "21.T11148/b9b76f887845e32d29f7");
         Optional<Date> date = typingService.getOperations().findDateCreated(pidRecord);
         assertTrue(date.isEmpty());
     }
@@ -58,11 +70,21 @@ public class OperationsTest {
     }
 
     @Test
-    void testFindDateModifiedFail() throws IOException {
+    void testFindDateModifiedFailUnregistered() throws IOException {
         PIDRecord pidRecord = new PIDRecord();
         // should fail because the type is not semantically recognizable as a date
         // (because it is not a registered type)
         pidRecord.addEntry("non-registered-creation-date", "", VALID_DATE);
+        Optional<Date> date = typingService.getOperations().findDateModified(pidRecord);
+        assertTrue(date.isEmpty());
+    }
+
+    @Test
+    void testFindDateModifiedFailRegistered() throws IOException {
+        PIDRecord pidRecord = new PIDRecord();
+        // should fail because the type is not semantically recognizable as a date
+        // (although it is a resolveable type)
+        pidRecord.addEntry(TYPE_PROFILE, "", "21.T11148/b9b76f887845e32d29f7");
         Optional<Date> date = typingService.getOperations().findDateModified(pidRecord);
         assertTrue(date.isEmpty());
     }

--- a/src/test/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticRepositoryTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticRepositoryTest.java
@@ -1,0 +1,82 @@
+package edu.kit.datamanager.pit.elasticsearch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.core.JacksonException;
+
+import edu.kit.datamanager.pit.domain.PIDRecord;
+import edu.kit.datamanager.pit.pitservice.ITypingService;
+import edu.kit.datamanager.pit.web.ApiMockUtils;
+
+@SpringBootTest
+@TestPropertySource(
+        locations = "/test/application-test.properties",
+        properties = {
+                "repo.search.enabled: true",
+                "management.health.elasticsearch.enabled: true"
+        }
+)
+@ActiveProfiles({"test", "elastic"})
+public class PidRecordElasticRepositoryTest {
+
+    @Autowired
+    private PidRecordElasticRepository dao;
+
+    @Autowired
+    private ITypingService typingService;
+
+    @BeforeEach
+    public void setUp() {
+        dao.deleteAll();
+    }
+
+    //@Test
+    @Transactional
+    void testEmpty() {
+        assertEquals(0, dao.count());
+    }
+
+    //@Test
+    @Transactional
+    void testStorage() throws JacksonException {
+        PIDRecord r = ApiMockUtils.getSomePidRecordInstance();
+        PidRecordElasticWrapper w = new PidRecordElasticWrapper(r, typingService.getOperations());
+        assertEquals(0, dao.count());
+        dao.save(w);
+        assertEquals(1, dao.count());
+    }
+
+    //@Test
+    @Transactional
+    void testMultipleValues() throws JacksonException {
+        PIDRecord r = ApiMockUtils.getSomePidRecordInstance();
+        r.addEntry(
+            r.getPropertyIdentifiers().stream().findFirst().get(), 
+            "", 
+            "testing");
+        PidRecordElasticWrapper w = new PidRecordElasticWrapper(r, typingService.getOperations());
+        assertEquals(0, dao.count());
+        dao.save(w);
+        assertEquals(1, dao.count());
+    }
+
+    //@Test
+    @Transactional
+    void testStorageWithDateNull() throws JacksonException {
+        PIDRecord r = new PIDRecord();
+        r.setPid("not-a-pid");
+        r.addEntry("21.T11148/076759916209e5d62bd5", "", "21.T11148/b9b76f887845e32d29f7");
+        PidRecordElasticWrapper w = new PidRecordElasticWrapper(r, typingService.getOperations());
+        assertEquals(0, dao.count());
+        dao.save(w);
+        assertEquals(1, dao.count());
+    }
+}

--- a/src/test/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticWrapperTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticWrapperTest.java
@@ -1,0 +1,40 @@
+package edu.kit.datamanager.pit.elasticsearch;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import com.fasterxml.jackson.core.JacksonException;
+
+import edu.kit.datamanager.pit.domain.PIDRecord;
+import edu.kit.datamanager.pit.pitservice.ITypingService;
+import edu.kit.datamanager.pit.web.ApiMockUtils;
+
+// JUnit5 + Spring
+@SpringBootTest
+// Set the in-memory implementation
+@TestPropertySource("/test/application-test.properties")
+@ActiveProfiles("test")
+public class PidRecordElasticWrapperTest {
+
+    @Autowired
+    ITypingService typingService;
+
+    @Test
+    void testCreateEmpty() {
+        PIDRecord pidRecord = new PIDRecord();
+        PidRecordElasticWrapper wrapper = new PidRecordElasticWrapper(pidRecord, typingService.getOperations());
+        assertNotNull(wrapper);
+    }
+
+    @Test
+    void testCreateValid() throws JacksonException {
+        PIDRecord pidRecord = ApiMockUtils.getSomePidRecordInstance();
+        PidRecordElasticWrapper wrapper = new PidRecordElasticWrapper(pidRecord, typingService.getOperations());
+        assertNotNull(wrapper);
+    }
+}

--- a/src/test/resources/test/application-test.properties
+++ b/src/test/resources/test/application-test.properties
@@ -209,8 +209,8 @@ pit.validation.strategy:embedded-strict
 
 pit.storage.strategy: keep-resolved-and-modified
 spring.datasource.driver-class-name: org.h2.Driver
-# WARNING: If no URL is being defined, an in-memory database is being used.
-#spring.datasource.url:  jdbc:h2:file:./database;MODE=LEGACY;NON_KEYWORDS=VALUE
+# WARNING: If no URL is being defined, a database file at /tmp/database is used.
+spring.datasource.url: jdbc:h2:mem:testDb;MODE=LEGACY;NON_KEYWORDS=VALUE
 spring.datasource.username: typid
 spring.datasource.password: secure_me
 spring.jpa.hibernate.ddl-auto: update

--- a/src/test/resources/test/application-test.properties
+++ b/src/test/resources/test/application-test.properties
@@ -86,93 +86,15 @@ repo.schedule.rate:1000
 
 repo.audit.enabled:true
 
-###################################
-##### Plugin Related Settings #####
-###################################
+############################################
+### Elastic Indexing and search endpoint ###
+############################################
 
-# The repository base URL used by a plugin to obtain resources via the RESTful API. 
-# This property is generic for all plugins and mainly depends on the property 
-# 'server.port' defined at the beginning of this document.
-repo.plugin.repositoryBaseUrl:http://localhost:8090/api/v1/dataresources/
-
-
-###################################
-######### OAI-PMH Plugin ##########
-###################################
-
-# Maximum number of elements delivered by the OAI-PMH endpoint (if enabled) before 
-# making use of resumption tokens.
-repo.plugin.oaipmh.maxElementsPerList:100
-
-##################################################
-######### Gemma Metadata Mapping Plugin ##########
-##################################################
-
-# Absolute path to the local python interpreter
-repo.plugin.gemma.pythonLocation:/Users/jejkal/anaconda/bin/python
-# Absolute path to the local gemma mapping script mapping_single.py' 
-repo.plugin.gemma.gemmaLocation:/Users/jejkal/NetBeansProjects/KITDM-2.0/gemma/mapping_single.py
-# Absolute path to the local gemma mappings folder
-repo.plugin.gemma.mappingsLocation:/Users/jejkal/NetBeansProjects/KITDM-2.0/gemma-plugin/mappings
-# List of schema mappings containing the content type as key in squared brackets and the 
-# according mapping filename as value. The mapping filename must be located at 
-# 'repo.plugin.gemma.mappingsLocation'.
-repo.plugin.gemma.schemaMappings[application/vnd.datamanager.data-resource+json]:simple_mapping.json
-repo.plugin.gemma.schemaMappings[application/json]:simple_mapping.json
-
-##################################################
-############ Elastic Indexing Plugin #############
-##################################################
-
-# Hostname and port of the elastic instance
-#repo.plugin.elastic.hostname:localhost
-#repo.plugin.elastic.port:9300
-
-# List of one or more indexing rules applied to repository content elements to decide
-# if and where an element should be indexed. Each rule has a type which is one of HAS_TAG,
-# PATH_MATCHES, or MEDIA_TYPE_MATCHES and an index which denotes the elastic index where
-# the according element will be registered to. The value differes between the rule types.
-# For PATCH_MATCHES value contains a regular expression matched against each content
-# element. A value of 'generated/.* means that all content elements in folder 'generated'
-# are matching the rule. Rule HAS_TAG compared assigned tags of a content element with
-# the provided tag. If multiple tags should be checked, multiple rules have to be defined
-# referring to the same index. The same applies to MEDIA_TYPE_MATCHES, where the 
-# media type of a content element is compared to the provided type.
-#repo.plugin.elastic.rules[0].type:PATH_MATCHES
-#repo.plugin.elastic.rules[0].value:generated/.*
-#repo.plugin.elastic.rules[0].index:myindex
-
-#repo.plugin.elastic.rules[1].type:HAS_TAG
-#repo.plugin.elastic.rules[1].value:do index
-#repo.plugin.elastic.rules[1].index:firstIndex
-
-#repo.plugin.elastic.rules[2].type:MEDIA_TYPE_MATCHES
-#repo.plugin.elastic.rules[2].value:application/json
-#repo.plugin.elastic.rules[2].index:firstIndex
-
-##################################################
-################## DOIP Plugin ###################
-##################################################
-repo.plugin.doip.enabled:true
-repo.plugin.doip.port:9000
-repo.plugin.doip.repoBaseUri:http://localhost:8090/api/v1/dataresources/
-
-#######################################################
-################## Content Versioning #################
-#######################################################
-
-#Can be one of: none, simple, ocfl
-repo.file.versioning.default:simple
-
-#OCFL Settings#
-ocfl.root.repositories.path=/Users/jejkal/tmp/ocfl/
-ocfl.storage.layout=flat
-ocfl.storage.layout.truncated.segment.length=4
-ocfl.storage.layout.truncated.dept.tree.length=3
-ocfl.root.repository.name=ocflRepository
-ocfl.hashing.digest.algorithm=md5
-ocfl.repository.statistics.file.name=statistic.json
-ocfl.default.repository=default
+# enables search endpoint at /api/v1/search
+repo.search.enabled: false
+management.health.elasticsearch.enabled: false
+repo.search.url: http://localhost:9200
+repo.search.index: *
 
 ################
 ### Keycloak ###


### PR DESCRIPTION
This PR adds the following (optional) features:

- [x] an endpoint for searching within PID records (and PIDs)
  - [x] Documentation is available via swagger (http://hostname:port/swagger-ui.html), as for all other endpoints.
- [x] direct indexing (without messaging) of PID records (and PIDs) using an Elasticsearch instance
  - [x] the PID and attributes of the record are indexed
  - [x] In addition, to have some compatibility to our other systems, try to extract creation and modification dates and duplicate them as createdAt and lastModified
- [x] options to disable or configure this feature
  - [x] Documented, as all other functions, in `config/application.properties`

---

- [x] Feature is mentioned in README
- [x] PR for webpage documentation update is prepared (should be merged on next release)
  - https://github.com/kit-data-manager/webpage/pull/32

---

- [x] make sure the attributes format in Elasticsearch is fine
- [x] add createdAt and lastModified attributes
- [x] check piped search endpoint once also manually
- [x] provide an example query from the swagger interface from some appropriate point in documentation
- [x] documentation states, that elastic 8 is the minimum requirement