### PR TITLE
Fix 148 add DOIP interface / add support for operation handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,10 @@ plugins {
     // https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/htmlsingle/
     id 'org.springframework.boot' version '2.7.13'
     // https://docs.spring.io/dependency-management-plugin/docs/current-SNAPSHOT/reference/html/
-    id "io.spring.dependency-management" version "1.1.2"
+    id "io.spring.dependency-management" version "1.1.3"
     // Lombok generates getter and setter and more. https://projectlombok.org/
     // check for new versions here: https://plugins.gradle.org/plugin/io.freefair.lombok
-    id "io.freefair.lombok" version "8.1.0"
+    id "io.freefair.lombok" version "8.3"
     // Release tagging with `./gradlew release`
     // Check for new versions here: https://plugins.gradle.org/plugin/net.researchgate.release
     // Usage: https://github.com/researchgate/gradle-release
@@ -20,7 +20,7 @@ plugins {
     // Adds coveralls task for CI to send results to the coveralls service.
     id "com.github.kt3k.coveralls" version "2.12.2"
     //id "com.github.kt3k.coveralls" version "2.12.0" 
-    id "org.owasp.dependencycheck" version "8.3.1"
+    id "org.owasp.dependencycheck" version "8.4.0"
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
     // include build and git information via Spring Actuator
     id "com.gorylenko.gradle-git-properties" version "2.4.1"
@@ -60,7 +60,7 @@ dependencies {
     implementation("edu.kit.datamanager:service-base:1.1.1")
     implementation("edu.kit.datamanager:repo-core:1.1.2")
     // com.google.common, LoadingCache
-    implementation("com.google.guava:guava:32.1.1-jre")
+    implementation("com.google.guava:guava:32.1.2-jre")
     // Required by Spring/Javers at runtime
     implementation 'com.google.code.gson:gson:2.10.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,7 @@ dependencies {
     implementation('org.apache.httpcomponents:httpclient-cache:4.5.14')
 
     implementation("net.handle:handle-client:9.3.1")
+    implementation("net.dona.doip:doip-sdk:2.1.0")
 
     testImplementation(platform('org.junit:junit-bom:5.10.0'))
 	testImplementation('org.junit.jupiter:junit-jupiter')

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@
 
 systemProp.jdk.tls.client.protocols="TLSv1,TLSv1.1,TLSv1.2"
 
-version=2.0.0
+version=1.1.2

--- a/src/main/java/edu/kit/datamanager/pit/domain/Operations.java
+++ b/src/main/java/edu/kit/datamanager/pit/domain/Operations.java
@@ -8,6 +8,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.joda.time.DateTime;
@@ -55,13 +56,13 @@ public class Operations {
      * @param pidRecord the record to extract the information from.
      * @return the extracted "supported types", if any.
      */
-    public List<String> findSupportedTypes(PIDRecord pidRecord) {
+    public Set<String> findSupportedTypes(PIDRecord pidRecord) {
         return KNOWN_SUPPORTED_TYPES
             .stream()
             .map(pidRecord::getPropertyValues)
             .map(Arrays::asList)
             .flatMap(List<String>::stream)
-            .collect(Collectors.toList());
+            .collect(Collectors.toSet());
     }
 
     /**
@@ -75,13 +76,13 @@ public class Operations {
      * @param pidRecord the record to extract the information from.
      * @return the extracted "supported locations", if any.
      */
-    public List<String> findSupportedLocations(PIDRecord pidRecord) {
+    public Set<String> findSupportedLocations(PIDRecord pidRecord) {
         return KNOWN_SUPPORTED_LOCATIONS
             .stream()
             .map(pidRecord::getPropertyValues)
             .map(Arrays::asList)
             .flatMap(List<String>::stream)
-            .collect(Collectors.toList());
+            .collect(Collectors.toSet());
     }
 
     /**

--- a/src/main/java/edu/kit/datamanager/pit/domain/Operations.java
+++ b/src/main/java/edu/kit/datamanager/pit/domain/Operations.java
@@ -8,6 +8,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
@@ -31,10 +32,56 @@ public class Operations {
         "21.T11148/397d831aa3a9d18eb52c"
     };
 
+    private static final List<String> KNOWN_SUPPORTED_TYPES = List.of(
+        "21.T11148/2694e4a7a5a00d44e62b"
+    );
+
+    private static final List<String> KNOWN_SUPPORTED_LOCATIONS = List.of();
+
     private ITypingService typingService;
 
     public Operations(ITypingService typingService) {
         this.typingService = typingService;
+    }
+
+    /**
+     * Tries to get supported types. Usually, this property only exists for FAIR DOs
+     * representing operations.
+     * 
+     * Strategy: - try to get it from known "dateModified" types
+     * 
+     * Semantic reasoning in some sense is planned but not yet supported.
+     * 
+     * @param pidRecord the record to extract the information from.
+     * @return the extracted "supported types", if any.
+     */
+    public List<String> findSupportedTypes(PIDRecord pidRecord) {
+        return KNOWN_SUPPORTED_TYPES
+            .stream()
+            .map(pidRecord::getPropertyValues)
+            .map(Arrays::asList)
+            .flatMap(List<String>::stream)
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Tries to get supported types. Usually, this property only exists for FAIR DOs
+     * representing operations.
+     * 
+     * Strategy: - try to get it from known "dateModified" types
+     * 
+     * Semantic reasoning in some sense is planned but not yet supported.
+     * 
+     * @param pidRecord the record to extract the information from.
+     * @return the extracted "supported locations", if any.
+     */
+    public List<String> findSupportedLocations(PIDRecord pidRecord) {
+        return KNOWN_SUPPORTED_LOCATIONS
+            .stream()
+            .map(pidRecord::getPropertyValues)
+            .map(Arrays::asList)
+            .flatMap(List<String>::stream)
+            .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticRepository.java
+++ b/src/main/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticRepository.java
@@ -27,5 +27,7 @@ import org.springframework.data.elasticsearch.repository.ElasticsearchRepository
 public interface PidRecordElasticRepository extends ElasticsearchRepository<PidRecordElasticWrapper, String> {
 
     Page<PidRecordElasticWrapper> findByPid(String pid, Pageable pageable);
+    Page<PidRecordElasticWrapper> findBySupportedLocation(String location);
+    Page<PidRecordElasticWrapper> findBySupportedType(String type);
 
 }

--- a/src/main/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticRepository.java
+++ b/src/main/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticRepository.java
@@ -32,9 +32,7 @@ public interface PidRecordElasticRepository extends ElasticsearchRepository<PidR
     Page<PidRecordElasticWrapper> findByPid(String pid, Pageable pageable);
 
     @Query("{\"match\": {\"supportedLocations\": \"?0\"}}")
-    Collection<PidRecordElasticWrapper> findBySupportedLocationsContain(
-        String location
-    );
+    Collection<PidRecordElasticWrapper> findBySupportedLocationsContain(String location);
 
     @Query("{\"match\": {\"supportedTypes\": \"?0\"}}")
     Collection<PidRecordElasticWrapper> findBySupportedTypesContain(String type);

--- a/src/main/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticRepository.java
+++ b/src/main/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticRepository.java
@@ -15,9 +15,12 @@
  */
 package edu.kit.datamanager.pit.elasticsearch;
 
+import java.util.Collection;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.annotations.Query;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
 /**
@@ -27,7 +30,13 @@ import org.springframework.data.elasticsearch.repository.ElasticsearchRepository
 public interface PidRecordElasticRepository extends ElasticsearchRepository<PidRecordElasticWrapper, String> {
 
     Page<PidRecordElasticWrapper> findByPid(String pid, Pageable pageable);
-    Page<PidRecordElasticWrapper> findBySupportedLocation(String location);
-    Page<PidRecordElasticWrapper> findBySupportedType(String type);
+
+    @Query("{\"match\": {\"supportedLocations\": \"?0\"}}")
+    Collection<PidRecordElasticWrapper> findBySupportedLocationsContain(
+        String location
+    );
+
+    @Query("{\"match\": {\"supportedTypes\": \"?0\"}}")
+    Collection<PidRecordElasticWrapper> findBySupportedTypesContain(String type);
 
 }

--- a/src/main/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticWrapper.java
+++ b/src/main/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticWrapper.java
@@ -54,18 +54,27 @@ public class PidRecordElasticWrapper {
     @Field(type = FieldType.Date, format = DateFormat.basic_date_time)
     private Date lastUpdate;
 
+    @ElementCollection(fetch = FetchType.EAGER)
+    private List<String> supportedTypes = new ArrayList<>();
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    private List<String> supportedLocations = new ArrayList<>();
+
     @Field(type = FieldType.Text)
     private List<String> read = new ArrayList<>();
 
-    public PidRecordElasticWrapper(PIDRecord pidRecord, Operations dateOperations) {
+    public PidRecordElasticWrapper(PIDRecord pidRecord, Operations recordOperations) {
         pid = pidRecord.getPid();
         PidDatabaseObject simple = new PidDatabaseObject(pidRecord);
         this.attributes = simple.getEntries();
         this.read.add("anonymousUser");
 
+        this.supportedTypes = recordOperations.findSupportedTypes(pidRecord);
+        this.supportedLocations = recordOperations.findSupportedLocations(pidRecord);
+        
         try {
-            this.created = dateOperations.findDateCreated(pidRecord).orElse(null);
-            this.lastUpdate = dateOperations.findDateModified(pidRecord).orElse(null);
+            this.created = recordOperations.findDateCreated(pidRecord).orElse(null);
+            this.lastUpdate = recordOperations.findDateModified(pidRecord).orElse(null);
         } catch (IOException e) {
             LOG.error("Could not retrieve date from record (pid: " + pidRecord.getPid() + ").", e);
             e.printStackTrace();

--- a/src/main/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticWrapper.java
+++ b/src/main/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticWrapper.java
@@ -63,6 +63,10 @@ public class PidRecordElasticWrapper {
     @Field(type = FieldType.Text)
     private List<String> read = new ArrayList<>();
 
+    protected PidRecordElasticWrapper() {
+        // for PidRecordElasticRepository
+    }
+
     public PidRecordElasticWrapper(PIDRecord pidRecord, Operations recordOperations) {
         pid = pidRecord.getPid();
         PidDatabaseObject simple = new PidDatabaseObject(pidRecord);
@@ -79,5 +83,72 @@ public class PidRecordElasticWrapper {
             LOG.error("Could not retrieve date from record (pid: " + pidRecord.getPid() + ").", e);
             e.printStackTrace();
         }
+    }
+
+    /**
+     * Generated with Lombok
+     */
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((pid == null) ? 0 : pid.hashCode());
+        result = prime * result + ((attributes == null) ? 0 : attributes.hashCode());
+        result = prime * result + ((created == null) ? 0 : created.hashCode());
+        result = prime * result + ((lastUpdate == null) ? 0 : lastUpdate.hashCode());
+        result = prime * result + ((supportedTypes == null) ? 0 : supportedTypes.hashCode());
+        result = prime * result + ((supportedLocations == null) ? 0 : supportedLocations.hashCode());
+        result = prime * result + ((read == null) ? 0 : read.hashCode());
+        return result;
+    }
+
+    /**
+     * Generated with Lombok
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        PidRecordElasticWrapper other = (PidRecordElasticWrapper) obj;
+        if (pid == null) {
+            if (other.pid != null)
+                return false;
+        } else if (!pid.equals(other.pid))
+            return false;
+        if (attributes == null) {
+            if (other.attributes != null)
+                return false;
+        } else if (!attributes.equals(other.attributes))
+            return false;
+        if (created == null) {
+            if (other.created != null)
+                return false;
+        } else if (!created.equals(other.created))
+            return false;
+        if (lastUpdate == null) {
+            if (other.lastUpdate != null)
+                return false;
+        } else if (!lastUpdate.equals(other.lastUpdate))
+            return false;
+        if (supportedTypes == null) {
+            if (other.supportedTypes != null)
+                return false;
+        } else if (!supportedTypes.equals(other.supportedTypes))
+            return false;
+        if (supportedLocations == null) {
+            if (other.supportedLocations != null)
+                return false;
+        } else if (!supportedLocations.equals(other.supportedLocations))
+            return false;
+        if (read == null) {
+            if (other.read != null)
+                return false;
+        } else if (!read.equals(other.read))
+            return false;
+        return true;
     }
 }

--- a/src/main/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticWrapper.java
+++ b/src/main/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticWrapper.java
@@ -23,8 +23,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.persistence.ElementCollection;
 import javax.persistence.FetchType;
@@ -55,10 +57,10 @@ public class PidRecordElasticWrapper {
     private Date lastUpdate;
 
     @ElementCollection(fetch = FetchType.EAGER)
-    private List<String> supportedTypes = new ArrayList<>();
+    private Set<String> supportedTypes = new HashSet<>();
 
     @ElementCollection(fetch = FetchType.EAGER)
-    private List<String> supportedLocations = new ArrayList<>();
+    private Set<String> supportedLocations = new HashSet<>();
 
     @Field(type = FieldType.Text)
     private List<String> read = new ArrayList<>();

--- a/src/main/java/edu/kit/datamanager/pit/pidlog/KnownPidsDao.java
+++ b/src/main/java/edu/kit/datamanager/pit/pidlog/KnownPidsDao.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 
 /**
  * Object to access known PIDs from the database.
@@ -18,6 +19,9 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
  * 
  * as well as the general concept documented in
  * https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#repositories.core-concepts
+ * 
+ * There is a introduction to a more high-level query language (JPQL) at
+ * https://www.baeldung.com/spring-data-jpa-query
  */
 public interface KnownPidsDao extends JpaRepository<KnownPid, String>, JpaSpecificationExecutor<KnownPid> {
     Optional<KnownPid> findByPid(String pid);
@@ -41,4 +45,10 @@ public interface KnownPidsDao extends JpaRepository<KnownPid, String>, JpaSpecif
     long countDistinctPidsByCreatedBetween(Instant from, Instant to);
 
     long countDistinctPidsByModifiedBetween(Instant from, Instant to);
+
+    @Query("SELECT DISTINCT(k) FROM KnownPid k WHERE ?1 MEMBER OF k.supportedLocations")
+    Collection<KnownPid> findBySupportedLocationsContain(String location);
+
+    @Query("SELECT DISTINCT(k) FROM KnownPid k WHERE ?1 MEMBER OF k.supportedTypes")
+    Collection<KnownPid> findBySupportedTypesContain(String type);
 }

--- a/src/main/java/edu/kit/datamanager/pit/web/doip/DoipOperationId.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/doip/DoipOperationId.java
@@ -1,0 +1,45 @@
+/*
+ * Adapted from https://git.rwth-aachen.de/nfdi4ing/s-3/s-3-3/metadatahub/-/blob/main/src/main/java/edu/kit/metadatahub/doip/rest/Operations.java
+ * 
+ * License: Apache 2.0
+ */
+
+package edu.kit.datamanager.pit.web.doip;
+
+import net.dona.doip.DoipConstants;
+
+/**
+ * Define valid operations for REST interface of DOIP.
+ */
+public enum DoipOperationId {
+    // Basic operations
+    OP_HELLO(DoipConstants.OP_HELLO),
+    OP_CREATE(DoipConstants.OP_CREATE),
+    OP_RETRIEVE(DoipConstants.OP_RETRIEVE),
+    OP_UPDATE(DoipConstants.OP_UPDATE),
+    OP_DELETE(DoipConstants.OP_DELETE),
+    OP_SEARCH(DoipConstants.OP_SEARCH),
+    OP_LIST(DoipConstants.OP_LIST_OPERATIONS),
+    // Extended operations
+    OP_VALIDATE("dev/Validation");
+
+    private final String value;
+
+    DoipOperationId(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static DoipOperationId fromValue(String v) {
+        for (DoipOperationId c : DoipOperationId.values()) {
+            if (c.value.equals(v)) {
+                return c;
+            }
+        }
+        throw new IllegalArgumentException(v);
+    }
+
+}

--- a/src/main/java/edu/kit/datamanager/pit/web/doip/DoipOverHttp.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/doip/DoipOverHttp.java
@@ -1,0 +1,179 @@
+/**
+ * A lot of code re-used from metadataHub, Apache 2.0 License.
+ * 
+ * Original Code: https://git.rwth-aachen.de/nfdi4ing/s-3/s-3-3/metadatahub/-/blob/main/src/main/java/edu/kit/metadatahub/rest/controller/Rest4DoipController.java
+ */
+
+package edu.kit.datamanager.pit.web.doip;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.commons.lang3.NotImplementedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.kit.datamanager.pit.pitservice.ITypingService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+/**
+ * REST controller for DOIP over HTTP.
+ */
+@RestController
+@CrossOrigin(origins = "*", allowedHeaders = "*")
+@ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "The request was processed successfully."),
+        @ApiResponse(responseCode = "400", description = "There was something wrong with the structure or content of the request"),
+        @ApiResponse(responseCode = "401", description = "The client must authenticate to perform the attempted operation"),
+        @ApiResponse(responseCode = "403", description = "The client was not permitted to perform the attempted operation"),
+        @ApiResponse(responseCode = "404", description = "The requested digital object could not be found"),
+        @ApiResponse(responseCode = "409", description = "There was a conflict preventing the request from being executed"),
+        @ApiResponse(responseCode = "500", description = "There was an internal server error") })
+public class DoipOverHttp {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DoipOverHttp.class);
+
+    private final String SELF_IDENTIFIER_FALLBACK = "self";
+    private final Collection<DoipOperationId> SERVICE_OPERATIONS = List.of(
+        //DoipOperationId.OP_HELLO,
+        //DoipOperationId.OP_CREATE,
+        //DoipOperationId.OP_RETRIEVE,
+        //DoipOperationId.OP_SEARCH,
+        DoipOperationId.OP_LIST
+    );
+    private final Collection<DoipOperationId> FAIRDO_OPERATIONS = List.of(
+        //DoipOperationId.OP_UPDATE,
+        //DoipOperationId.OP_DELETE,
+        DoipOperationId.OP_LIST
+        //DoipOperationId.OP_VALIDATE
+    );
+
+    @Autowired
+    ITypingService pit;
+
+    public DoipResponse op_server_create(
+            final DoipOperationId operationId,
+            final String targetId,
+            final String clientId,
+            final JsonNode attributes,
+            final DoipRequest body
+    ) {
+        throw new NotImplementedException();
+    }
+
+    /**
+     * DOIP Entpoint. Basically executes targetId.operationId(attributes, body, clientId).
+     */
+    @Operation(summary = "DOIPv2 over HTTP.", description = "DOIPv2 via HTTP as defined by Cordra, as far as applicable.")
+    @PostMapping(value = { "/doip" }, consumes = { MediaType.ALL_VALUE })
+    @ResponseBody
+    public ResponseEntity<DoipResponse> postDoipOperation(
+            @Parameter(description = "The operationId.", required = true)
+            @RequestParam(value = "operationId")
+            final DoipOperationId operationId,
+
+            @Parameter(description = "The targetId.", required = true)
+            @RequestParam(value = "targetId")
+            final String targetId,
+
+            @Parameter(description = "the identifier of the caller", required = true)
+            @RequestParam(value = "clientId")
+            final String clientId,
+
+            @Parameter(description = "arbitrary JSON to inform the operation", required = true)
+            @RequestParam(value = "attributes")
+            final JsonNode attributes,
+
+            @Parameter(description = "Json representation of the Digital Object.", required = false)
+            @RequestBody(required = false)
+            final DoipRequest body
+    ) {
+        // Authentication: is done by security layer (keycloak / JWT)
+
+        boolean isServiceTarget = Objects.equals(targetId, SELF_IDENTIFIER_FALLBACK) /* TODO or a real identifier configured for this service? */;
+
+        if (isServiceTarget) {
+            switch (operationId) {
+                case OP_LIST:
+                    return operation_service_list(targetId, operationId, body, attributes, clientId);
+                //case OP_HELLO:
+                //    break;
+                //case OP_CREATE:
+                //    break;
+                //case OP_RETRIEVE:
+                //    break;
+                //case OP_SEARCH:
+                //    break;
+                default:
+                    DoipResponse r = new DoipResponse(DoipStatus.REQUEST_INVALID);
+                    return new ResponseEntity<>(r, r.getDoipStatus().getHttpStatus());
+            }
+        } else {
+            // check if identifier is registered
+            if (pit.isIdentifierRegistered(targetId)) {
+                switch (operationId) {
+                    case OP_LIST:
+                        return operation_fairdo_list(targetId, operationId, body, attributes, clientId);
+                    //case OP_UPDATE:
+                    //    break;
+                    //case OP_DELETE:
+                    //    break;
+                    //case OP_VALIDATE:
+                    //    break;
+                    default:
+                        DoipResponse r = new DoipResponse(DoipStatus.REQUEST_INVALID);
+                        return new ResponseEntity<>(r, r.getDoipStatus().getHttpStatus());
+                }
+            } else {
+                DoipResponse r = new DoipResponse(DoipStatus.DIGITAL_OBJECT_NOT_FOUND);
+                return new ResponseEntity<>(r, r.getDoipStatus().getHttpStatus());
+            }
+            // if not, return error
+        }
+    }
+
+    private ResponseEntity<DoipResponse> operation_fairdo_list(
+        String targetId,
+        DoipOperationId operationId,
+        DoipRequest body,
+        JsonNode attributes,
+        String clientId
+    ){
+        ObjectMapper mapper = new ObjectMapper();
+        DoipResponse r = new DoipResponse(DoipStatus.OPERATION_SUCCESS);
+        // TODO add other known operations
+        r.setOutput(mapper.valueToTree(FAIRDO_OPERATIONS));
+        return new ResponseEntity<>(r, r.getDoipStatus().getHttpStatus());
+    }
+
+    private ResponseEntity<DoipResponse> operation_service_list(
+        String targetId,
+        DoipOperationId operationId,
+        DoipRequest body,
+        JsonNode attributes,
+        String clientId
+    ) {
+        ObjectMapper mapper = new ObjectMapper();
+        DoipResponse r = new DoipResponse(DoipStatus.OPERATION_SUCCESS);
+        r.setOutput(mapper.valueToTree(SERVICE_OPERATIONS));
+        return new ResponseEntity<>(r, r.getDoipStatus().getHttpStatus());
+	}
+
+}

--- a/src/main/java/edu/kit/datamanager/pit/web/doip/DoipRequest.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/doip/DoipRequest.java
@@ -1,0 +1,84 @@
+/*
+ * Adapted from: https://git.rwth-aachen.de/nfdi4ing/s-3/s-3-3/metadatahub/-/blob/main/src/main/java/edu/kit/metadatahub/doip/rest/RestDoip.java#L39
+ * 
+ * License: Apache 2.0
+ */
+package edu.kit.datamanager.pit.web.doip;
+
+import java.util.ArrayList;
+import java.util.List;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import edu.kit.datamanager.pit.domain.SimplePair;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "id",
+    "clientId",
+    "attributes"
+})
+public class DoipRequest {
+
+    @JsonProperty("id")
+    private String id;
+    @JsonProperty("clientId")
+    private String clientId;
+    @JsonProperty("targetId")
+    private String targetId;
+    @JsonProperty("token")
+    private String token;
+    @JsonProperty("attributes")
+    private List<SimplePair> attributes = new ArrayList<>();
+
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @JsonProperty("clientId")
+    public String getClientId() {
+        return clientId;
+    }
+
+    @JsonProperty("clientId")
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    @JsonProperty("targetId")
+    public String getTargetId() {
+        return targetId;
+    }
+
+    @JsonProperty("targetId")
+    public void setTargetId(String targetId) {
+        this.targetId = targetId;
+    }
+
+    @JsonProperty("token")
+    public String getToken() {
+        return token;
+    }
+
+    @JsonProperty("token")
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    @JsonProperty("attributes")
+    public List<SimplePair> getAttributes() {
+        return attributes;
+    }
+
+    @JsonProperty("attributes")
+    public void setAttributes(List<SimplePair> attributes) {
+        this.attributes = attributes;
+    }
+}

--- a/src/main/java/edu/kit/datamanager/pit/web/doip/DoipResponse.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/doip/DoipResponse.java
@@ -1,0 +1,84 @@
+package edu.kit.datamanager.pit.web.doip;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.JsonNode;
+
+// Serialize everything which is not null
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ "status", "attributes", "output" })
+public class DoipResponse {
+
+    @JsonIgnore
+    private DoipStatus doipStatus;
+    
+    /**
+     * An identifier that indicates the status of the request.
+     */
+    private String status;
+    
+    /**
+     * Optional array of JSON properties; operation stipulated.
+     */
+    private List<JsonNode> attributes;
+    
+    /**
+     * arbitrary information returned to the client, depending on the operation. If
+     * absent, the output for the operation is all segments that follow this
+     * response object. If present the output is the JSON object corresponding to
+     * the output property, and there must be no further non-empty segments in the
+     * request.
+     */
+    private JsonNode output;
+
+    DoipResponse(DoipStatus status, List<JsonNode> attributes, JsonNode output) {
+        this.doipStatus = status;
+        this.status = status.getIdentifier();
+        this.attributes = attributes;
+        this.output = output;
+    }
+
+    DoipResponse(DoipStatus status) {
+        this.status = status.getIdentifier();
+    }
+
+    @JsonIgnore
+    public DoipStatus getDoipStatus() {
+        return doipStatus;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.doipStatus = DoipStatus.fromIdentifier(status);
+        this.status = status;
+    }
+    
+    public List<JsonNode> getAttributes() {
+        return attributes;
+    }
+    
+    public void setAttributes(List<JsonNode> attributes) {
+        this.attributes = attributes;
+    }
+    
+    public JsonNode getOutput() {
+        return output;
+    }
+    
+    public void setOutput(JsonNode output) {
+        this.output = output;
+    }
+
+    @JsonIgnore
+    public ResponseEntity<DoipResponse> asResponseEntity() {
+        return new ResponseEntity<>(this, this.getDoipStatus().getHttpStatus());
+    }
+}

--- a/src/main/java/edu/kit/datamanager/pit/web/doip/DoipStatus.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/doip/DoipStatus.java
@@ -1,0 +1,75 @@
+package edu.kit.datamanager.pit.web.doip;
+
+import org.springframework.http.HttpStatus;
+
+import net.dona.doip.DoipConstants;
+
+/**
+ * Define valid operations for REST interface of DOIP.
+ */
+public enum DoipStatus {
+    OPERATION_SUCCESS(
+        DoipConstants.STATUS_OK,
+        HttpStatus.OK,
+        "The operation was successfully processed."),
+    REQUEST_INVALID(
+        DoipConstants.STATUS_BAD_REQUEST,
+        HttpStatus.BAD_REQUEST,
+        "The request was invalid in some way."),
+    AUTHENTICATION_FAIL(
+        DoipConstants.STATUS_UNAUTHENTICATED,
+        HttpStatus.UNAUTHORIZED,
+        "The client did not successfully authenticate."),
+    OPERATION_UNAUTHORIZED(
+        DoipConstants.STATUS_FORBIDDEN,
+        HttpStatus.FORBIDDEN,
+        "The client successfully authenticated, but is unauthorized to invoke the operation."),
+    DIGITAL_OBJECT_NOT_FOUND(
+        DoipConstants.STATUS_NOT_FOUND,
+        HttpStatus.NOT_FOUND,
+        "The digital object is not known to the service to exist."),
+    PID_ALREADY_REGISTERED(
+        DoipConstants.STATUS_CONFLICT,
+        HttpStatus.CONFLICT,
+        "The client tried to create a new digital object with an identifier already in use by an existing digital object."),
+    OPERATION_EXECUTION_DECLINED(
+        DoipConstants.STATUS_DECLINED,
+        HttpStatus.BAD_REQUEST,
+        "The service declines to execute the extended operation."),
+    OTHER(
+        DoipConstants.STATUS_ERROR,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        "Error other than the ones stated above occurred.");
+
+    private final String identifier;
+    private final HttpStatus httpStatus;
+    private final String description;
+    
+    DoipStatus(String v, HttpStatus http, String description) {
+        this.identifier = v;
+        this.httpStatus = http;
+        this.description = description;
+    }
+    
+    public String getIdentifier() {
+        return identifier;
+    }
+    
+    public String getDescription() {
+        return description;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+    
+    public static DoipStatus fromIdentifier(String v) {
+        for (DoipStatus c : DoipStatus.values()) {
+            if (c.identifier.equals(v)) {
+                return c;
+            }
+        }
+        throw new IllegalArgumentException(v);
+    }
+
+}

--- a/src/test/java/edu/kit/datamanager/pit/domain/OperationsTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/domain/OperationsTest.java
@@ -1,11 +1,13 @@
 package edu.kit.datamanager.pit.domain;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.Date;
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +27,7 @@ public class OperationsTest {
 
     public static final String VALID_DATE = "2021-12-21T17:36:09.541+00:00";
     public static final String TYPE_PROFILE = "21.T11148/076759916209e5d62bd5";
+    public static final String TYPE_DOTYPE = "21.T11148/1c699a5d1b4ad3ba4956";
 
     @Autowired
     private ITypingService typingService;
@@ -87,6 +90,16 @@ public class OperationsTest {
         pidRecord.addEntry(TYPE_PROFILE, "", "21.T11148/b9b76f887845e32d29f7");
         Optional<Date> date = typingService.getOperations().findDateModified(pidRecord);
         assertTrue(date.isEmpty());
+    }
+
+    @Test
+    void testFindDigitalObjectTypesSuccess() throws IOException {
+        PIDRecord pidRecord = new PIDRecord();
+        String myType = "my/type";
+        pidRecord.addEntry(TYPE_DOTYPE, "", myType);
+        pidRecord.addEntry(TYPE_DOTYPE, "", myType + "2");
+        Set<String> doTypes = typingService.getOperations().findDigitalObjectTypes(pidRecord);
+        assertEquals(2, doTypes.size());
     }
 
     @Test

--- a/src/test/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticRepositoryTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticRepositoryTest.java
@@ -2,6 +2,8 @@ package edu.kit.datamanager.pit.elasticsearch;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Collection;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -80,5 +82,24 @@ public class PidRecordElasticRepositoryTest {
         assertEquals(0, dao.count());
         dao.save(w);
         assertEquals(1, dao.count());
+    }
+
+    @Test
+    @Transactional
+    void testRetrieveBySupportedType() throws JacksonException {
+        PIDRecord r = new PIDRecord();
+        r.setPid("not-a-pid");
+        String supportedType = "some/supported-type";
+        r.addEntry("21.T11148/2694e4a7a5a00d44e62b", "", supportedType);
+        r.addEntry("21.T11148/2694e4a7a5a00d44e62b", "", "second/supported-type");
+        PidRecordElasticWrapper w = new PidRecordElasticWrapper(r, typingService.getOperations());
+        assertEquals(0, dao.count());
+        dao.save(w);
+        assertEquals(1, dao.count());
+        Collection<PidRecordElasticWrapper> result = dao.findBySupportedLocationsContain("other/type");
+        assertEquals(0, result.size());
+        result = dao.findBySupportedTypesContain(supportedType);
+        assertEquals(1, result.size());
+        assertEquals(w, result.iterator().next());
     }
 }


### PR DESCRIPTION
> NOTE: In this branch, we implement DOIP, while at the same time experimenting with specialized handling of FAIR DOs which represent operations. It will allow to enhance the listOperation from the DOIP specificaton in a non-trivial manner. The goal is to also list operations which are not supported by the Typed PID Maker directly. Instead it offers all compatible operations it encountered.

This branch is based on #125. At some point, this branch may be used to test DOIP and the new features / adjustment coming in #125. If you like to test DOIP in Typed PID Maker, use this branch, as long as it has not been merged.

- [x] Implement generic DOIP over HTTP structure
- [x] Implement service.listOperations
- [x] Implement fairdo.listOperations
  - [x] add possibility to extract supported type/location information and to store it into the database
    - [x] + elasticsearch
  - [x] write sanity tests for retrieving this information from the database (and implement retrieval)
    - [x] + elasticsearch
  - [x] allow extracting this information via DOIP (over http)
- [x] write some documentation somewhere (maybe just in this issue) so it can already be tested while going on

---

- [x] write tests as far as possible
- [x] I need some details about how exactly the compatibility of an Operation with an Operation should be done, so I can support all cases. (will be integrated in tasks below, done)
- [ ] support this types content (which has changes in the meanwhile): https://dtr-test.pidconsortium.net/#objects/21.T11148/2694e4a7a5a00d44e62b
- [ ] if multiple instance of this type are available, assume "and" or "or" (awaiting response)
- [x] we do not need to look for intermediate objects here
- [ ] The LIST functionality may be interesting for the REST interface also: Implement it. When doing so, consider refactoring the code for better reuse. One idea would be to integrate it into the TypingService interface/implementation.

---

All other functionality is already available via REST, but for consistency, let's also implement the other operations.

> Note: Consider refactoring the code in the REST interface for better reuse in other interface modules when implementing these steps.

- [ ] Implement service.hello?
- [ ] Implement service.create
- [ ] Implement service.retrieve (incl. validate? notice possible changes in #125)
- [ ] Implement service.search
- [ ] Implement fairdo.update
- [ ] Implement fairdo.delete (tombstone)
- [ ] Implement fairdo.validate (notice possible changes in #125)

---

- [ ] merge master branch and make sure everything is consistent.
- [ ] merge into master branch or version-specific dev branch, if desired.