### PR TITLE
115 Upgrade Spring Boot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     implementation("edu.kit.datamanager:service-base:1.2.0")
     implementation("edu.kit.datamanager:repo-core:1.2.1")
     // com.google.common, LoadingCache
-    implementation("com.google.guava:guava:32.1.2-jre")
+    implementation("com.google.guava:guava:32.1.3-jre")
     // Required by Spring/Javers at runtime
     implementation 'com.google.code.gson:gson:2.10.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,8 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
     testImplementation("org.springframework.security:spring-security-test")
+
+    testImplementation("com.jayway.jsonpath:json-path:2.8.0")
 }
 
 application {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     // Spring boot & dependency management:
     // https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/htmlsingle/
-    id 'org.springframework.boot' version '3.1.3'
+    id 'org.springframework.boot' version '3.1.5'
     // https://docs.spring.io/dependency-management-plugin/docs/current-SNAPSHOT/reference/html/
     id "io.spring.dependency-management" version "1.1.3"
     // Lombok generates getter and setter and more. https://projectlombok.org/

--- a/build.gradle
+++ b/build.gradle
@@ -212,3 +212,8 @@ release {
         requireBranch.set("master")
     }
 }
+
+tasks.withType(Jar).all { duplicatesStrategy(DuplicatesStrategy.EXCLUDE) }
+tasks.withType(Tar).all { duplicatesStrategy(DuplicatesStrategy.EXCLUDE) }
+tasks.withType(Copy).all { duplicatesStrategy(DuplicatesStrategy.EXCLUDE) }
+tasks.withType(Zip).all { duplicatesStrategy(DuplicatesStrategy.EXCLUDE) }

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ repositories {
 ext {
     springDocVersion  = '1.7.0'
 }
+ext['spring-security.version']='5.8.6'
 
 dependencies {
     // Due to the spring boot gradle plugin, we can omit versions in org.springframework.*

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     // Spring boot & dependency management:
     // https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/htmlsingle/
-    id 'org.springframework.boot' version '2.7.15'
+    id 'org.springframework.boot' version '3.1.3'
     // https://docs.spring.io/dependency-management-plugin/docs/current-SNAPSHOT/reference/html/
     id "io.spring.dependency-management" version "1.1.3"
     // Lombok generates getter and setter and more. https://projectlombok.org/
@@ -53,13 +53,12 @@ repositories {
 ext {
     springDocVersion  = '1.7.0'
 }
-ext['spring-security.version']='5.8.6'
 
 dependencies {
     // Due to the spring boot gradle plugin, we can omit versions in org.springframework.*
     // dependencies. It will automatically choose the fitting ones.
-    implementation("edu.kit.datamanager:service-base:1.1.1")
-    implementation("edu.kit.datamanager:repo-core:1.1.2")
+    implementation("edu.kit.datamanager:service-base:1.2.0")
+    implementation("edu.kit.datamanager:repo-core:1.2.1")
     // com.google.common, LoadingCache
     implementation("com.google.guava:guava:32.1.2-jre")
     // Required by Spring/Javers at runtime

--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,7 @@ plugins {
     id 'jacoco'
     // Adds coveralls task for CI to send results to the coveralls service.
     id "com.github.kt3k.coveralls" version "2.12.2"
-    //id "com.github.kt3k.coveralls" version "2.12.0" 
     id "org.owasp.dependencycheck" version "8.4.0"
-    id 'org.asciidoctor.jvm.convert' version '3.3.2'
     // include build and git information via Spring Actuator
     id "com.gorylenko.gradle-git-properties" version "2.4.1"
 }
@@ -119,12 +117,6 @@ bootJar {
         // https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/htmlsingle/#packaging-executable.configuring.main-class
         // https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/loader/PropertiesLauncher.html
         attributes 'Main-Class': 'org.springframework.boot.loader.PropertiesLauncher'
-    }
-
-    // Include documentation to be available on runtime.
-    dependsOn asciidoctor
-    from ("${asciidoctor.outputDir}/html5") {
-        into 'static/docs'
     }
 
     // Make the Typed PID Maker executable without `java -jar`

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ lombok {
 
 jacoco {
     // check here for new versions: https://www.jacoco.org/jacoco/
-    toolVersion = "0.8.10"
+    toolVersion = "0.8.11"
 }
 
 archivesBaseName = 'TypedPIDMaker'

--- a/build.gradle
+++ b/build.gradle
@@ -26,12 +26,12 @@ plugins {
 
 lombok {
     // check here for new versions: https://projectlombok.org/download
-    version = '1.18.22'
+    version = '1.18.28'
 }
 
 jacoco {
     // check here for new versions: https://www.jacoco.org/jacoco/
-    toolVersion = "0.8.7"
+    toolVersion = "0.8.10"
 }
 
 archivesBaseName = 'TypedPIDMaker'

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ repositories {
 }
 
 ext {
-    springDocVersion  = '1.7.0'
+    springDocVersion  = '2.2.0'
 }
 
 dependencies {
@@ -77,9 +77,8 @@ dependencies {
     // @EnableJPARepositories
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
     // springdoc / openapi / swagger
-    implementation "org.springdoc:springdoc-openapi-ui:${springDocVersion}"
-    implementation "org.springdoc:springdoc-openapi-data-rest:${springDocVersion}"
-    implementation "org.springdoc:springdoc-openapi-webmvc-core:${springDocVersion}"
+    implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:${springDocVersion}"
+    implementation "org.springdoc:springdoc-openapi-starter-webmvc-api:${springDocVersion}"
     // spring + elasticsearch communication
     implementation "org.springframework.data:spring-data-elasticsearch"
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id "io.spring.dependency-management" version "1.1.3"
     // Lombok generates getter and setter and more. https://projectlombok.org/
     // check for new versions here: https://plugins.gradle.org/plugin/io.freefair.lombok
-    id "io.freefair.lombok" version "8.3"
+    id "io.freefair.lombok" version "8.4"
     // Release tagging with `./gradlew release`
     // Check for new versions here: https://plugins.gradle.org/plugin/net.researchgate.release
     // Usage: https://github.com/researchgate/gradle-release
@@ -26,7 +26,7 @@ plugins {
 
 lombok {
     // check here for new versions: https://projectlombok.org/download
-    version = '1.18.28'
+    version = '1.18.30'
 }
 
 jacoco {

--- a/config/application.properties
+++ b/config/application.properties
@@ -1,6 +1,7 @@
 ### General Spring Boot Settings ###
 # When to include "message" attribute in HTTP responses on uncatched exceptions.
 server.error.include-message: always
+springdoc.show-actuator=true
 # Do __not__ change these settings below:
 spring.main.allow-bean-definition-overriding=true
 spring.data.rest.detection-strategy:annotated

--- a/config/application.properties
+++ b/config/application.properties
@@ -92,9 +92,16 @@ spring.autoconfigure.exclude=org.keycloak.adapters.springboot.KeycloakAutoConfig
 
 # enables search endpoint at /api/v1/search
 repo.search.enabled: false
-management.health.elasticsearch.enabled: false
-repo.search.url: http://localhost:9200
 repo.search.index: *
+management.health.elasticsearch.enabled: false
+
+# TO BE REMOVED!
+repo.search.url: http://localhost:9200
+# Soon will be:
+#spring.elasticsearch.uris=http://localhost:9200
+#spring.elasticsearch.username=user
+#spring.elasticsearch.password=secret
+#spring.elasticsearch.socket-timeout=10s
 
 #################
 ### Messaging ###

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/edu/kit/datamanager/pit/Application.java
+++ b/src/main/java/edu/kit/datamanager/pit/Application.java
@@ -62,13 +62,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Scope;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-import org.springframework.http.client.BufferingClientHttpRequestFactory;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.web.client.RestTemplate;
 
 /**
  *
@@ -121,17 +117,6 @@ public class Application {
                 .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS) // ISODate
                 .modules(new JavaTimeModule())
                 .build();
-    }
-
-    @Bean
-    public RestTemplate restTemplate() {
-        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
-        RestTemplate restTemplate = new RestTemplate(requestFactory);
-        // BufferingClientHttpRequestFactory allows us to read the response more than
-        // once - Necessary for debugging.
-        restTemplate.setRequestFactory(
-                new BufferingClientHttpRequestFactory(new HttpComponentsClientHttpRequestFactory(httpClient())));
-        return restTemplate;
     }
 
     @Bean

--- a/src/main/java/edu/kit/datamanager/pit/configuration/ApplicationProperties.java
+++ b/src/main/java/edu/kit/datamanager/pit/configuration/ApplicationProperties.java
@@ -22,7 +22,7 @@ import edu.kit.datamanager.pit.pitservice.impl.NoValidationStrategy;
 
 import java.net.URL;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/edu/kit/datamanager/pit/configuration/ElasticConfiguration.java
+++ b/src/main/java/edu/kit/datamanager/pit/configuration/ElasticConfiguration.java
@@ -20,19 +20,16 @@ import edu.kit.datamanager.configuration.SearchConfiguration;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
 import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
-import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 
 /*
  * https://docs.spring.io/spring-boot/docs/3.0.x/reference/html/data.html#data.nosql.elasticsearch.connecting-using-rest.javaapiclient
+ * https://docs.spring.io/spring-data/elasticsearch/docs/current/reference/html/#elasticsearch.clients.restclient
  */
 @Configuration
-@EnableElasticsearchRepositories(basePackages = "edu.kit.datamanager.repo")
-@ComponentScan(basePackages = {"edu.kit.datamanager"})
-@ConditionalOnProperty(prefix = "repo.search", name = "enabled", havingValue = "true")
+@ConditionalOnProperty(prefix = "repo.search", name="enabled", havingValue = "true", matchIfMissing = false)
 public class ElasticConfiguration extends ElasticsearchConfiguration {
 
     @Autowired
@@ -40,9 +37,9 @@ public class ElasticConfiguration extends ElasticsearchConfiguration {
 
     @Override
 	public ClientConfiguration clientConfiguration() {
-        // URL and API key
         String serverUrl = searchConfiguration.getUrl().toString();
-        // String apiKey = searchConfiguration.get???;
+        serverUrl = serverUrl.replace("http://", "");
+        serverUrl = serverUrl.replace("https://", "");
 
         return ClientConfiguration.builder()
                 .connectedTo(serverUrl)

--- a/src/main/java/edu/kit/datamanager/pit/configuration/ElasticConfiguration.java
+++ b/src/main/java/edu/kit/datamanager/pit/configuration/ElasticConfiguration.java
@@ -17,50 +17,35 @@ package edu.kit.datamanager.pit.configuration;
  */
 
 import edu.kit.datamanager.configuration.SearchConfiguration;
-import org.elasticsearch.client.RestHighLevelClient;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
-import org.springframework.data.elasticsearch.client.RestClients;
-import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
-import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
-import org.springframework.http.HttpHeaders;
 
+/*
+ * https://docs.spring.io/spring-boot/docs/3.0.x/reference/html/data.html#data.nosql.elasticsearch.connecting-using-rest.javaapiclient
+ */
 @Configuration
 @EnableElasticsearchRepositories(basePackages = "edu.kit.datamanager.repo")
 @ComponentScan(basePackages = {"edu.kit.datamanager"})
 @ConditionalOnProperty(prefix = "repo.search", name = "enabled", havingValue = "true")
-public class ElasticConfiguration {
+public class ElasticConfiguration extends ElasticsearchConfiguration {
 
     @Autowired
-    private SearchConfiguration searchConfiguration;
+    SearchConfiguration searchConfiguration;
 
-    @Bean
-    public RestHighLevelClient client() {
-        //required for compatibility to Elastic 8.X ... might not work and should be removed with spring-boot 3.X
-        HttpHeaders compatibilityHeaders = new HttpHeaders();
-        compatibilityHeaders.add("Accept", "application/vnd.elasticsearch+json;compatible-with=7");
-        compatibilityHeaders.add("Content-Type", "application/vnd.elasticsearch+json;compatible-with=7");
+    @Override
+	public ClientConfiguration clientConfiguration() {
+        // URL and API key
+        String serverUrl = searchConfiguration.getUrl().toString();
+        // String apiKey = searchConfiguration.get???;
 
-        String indexUrl = searchConfiguration.getUrl().toString();
-        String hostnamePort = indexUrl.substring(indexUrl.indexOf("//") + 2);
-
-        ClientConfiguration clientConfiguration
-                = ClientConfiguration.builder()
-                        .connectedTo(hostnamePort)
-                        .withDefaultHeaders(compatibilityHeaders)
-                        .build();
-
-        return RestClients.create(clientConfiguration).rest();
+        return ClientConfiguration.builder()
+                .connectedTo(serverUrl)
+                .build();
     }
-
-    @Bean
-    public ElasticsearchOperations elasticsearchTemplate() {
-        return new ElasticsearchRestTemplate(client());
-    }
-
 }

--- a/src/main/java/edu/kit/datamanager/pit/configuration/ElasticConfiguration.java
+++ b/src/main/java/edu/kit/datamanager/pit/configuration/ElasticConfiguration.java
@@ -32,8 +32,11 @@ import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfigurat
 @ConditionalOnProperty(prefix = "repo.search", name="enabled", havingValue = "true", matchIfMissing = false)
 public class ElasticConfiguration extends ElasticsearchConfiguration {
 
-    @Autowired
-    SearchConfiguration searchConfiguration;
+    private final SearchConfiguration searchConfiguration;
+    
+    public ElasticConfiguration(@Autowired SearchConfiguration searchConfiguration) {
+        this.searchConfiguration = searchConfiguration;
+    }
 
     @Override
 	public ClientConfiguration clientConfiguration() {

--- a/src/main/java/edu/kit/datamanager/pit/configuration/HandleCredentials.java
+++ b/src/main/java/edu/kit/datamanager/pit/configuration/HandleCredentials.java
@@ -6,10 +6,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import javax.annotation.Nullable;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/edu/kit/datamanager/pit/configuration/PidGenerationProperties.java
+++ b/src/main/java/edu/kit/datamanager/pit/configuration/PidGenerationProperties.java
@@ -2,7 +2,7 @@ package edu.kit.datamanager.pit.configuration;
 
 import java.util.Optional;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/edu/kit/datamanager/pit/configuration/WebSecurityConfig.java
+++ b/src/main/java/edu/kit/datamanager/pit/configuration/WebSecurityConfig.java
@@ -51,16 +51,22 @@ import org.springframework.web.filter.CorsFilter;
 @EnableMethodSecurity(prePostEnabled = true)
 public class WebSecurityConfig {
 
-  @Autowired
-  private KeycloakJwtProperties properties;
+  private final KeycloakJwtProperties properties;
 
-  @Autowired
-  private ApplicationProperties config;
+  private final ApplicationProperties config;
 
   @Value("${pit.security.enable-csrf:true}")
   private boolean enableCsrf;
   @Value("${pit.security.allowedOriginPattern:http*://localhost:[*]}")
   private String allowedOriginPattern;
+
+  public WebSecurityConfig(
+    @Autowired KeycloakJwtProperties properties,
+    @Autowired ApplicationProperties config
+  ) {
+    this.properties = properties;
+    this.config = config;
+  }
 
   @Bean
   protected SecurityFilterChain filterChain(HttpSecurity http, Logger logger) throws Exception {

--- a/src/main/java/edu/kit/datamanager/pit/configuration/WebSecurityConfig.java
+++ b/src/main/java/edu/kit/datamanager/pit/configuration/WebSecurityConfig.java
@@ -70,6 +70,9 @@ public class WebSecurityConfig {
         // everyone, even unauthenticated users may do HTTP OPTIONS on urls.
         .authorizeHttpRequests()
         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+        .requestMatchers(HttpMethod.GET, "/swagger-ui.html").permitAll()
+        .requestMatchers(HttpMethod.GET, "/swagger-ui/**").permitAll()
+        .requestMatchers(HttpMethod.GET, "/v3/**").permitAll()
         .requestMatchers("/api/v1/**").authenticated()
         .and()
         // do not store sessions (use stateless "sessions")

--- a/src/main/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticWrapper.java
+++ b/src/main/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticWrapper.java
@@ -26,8 +26,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.persistence.ElementCollection;
-import javax.persistence.FetchType;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.FetchType;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/edu/kit/datamanager/pit/pidlog/KnownPid.java
+++ b/src/main/java/edu/kit/datamanager/pit/pidlog/KnownPid.java
@@ -4,10 +4,10 @@ import java.io.Serializable;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 /**
  * Stores information about a known PID so it can be stored in a database.

--- a/src/main/java/edu/kit/datamanager/pit/pidsystem/impl/HandleProtocolAdapter.java
+++ b/src/main/java/edu/kit/datamanager/pit/pidsystem/impl/HandleProtocolAdapter.java
@@ -514,21 +514,27 @@ public class HandleProtocolAdapter implements IIdentifierSystem {
         private final Collection<HandleValue> toUpdate = new ArrayList<>();
         private final Collection<HandleValue> toRemove = new ArrayList<>();
 
-        HandleDiff(final Map<Integer, HandleValue> recordOld, final Map<Integer, HandleValue> recordNew)
-                throws PidUpdateException {
-            // old_indexes should only contain indexes we do not override/update anyway, so
-            // we can delete them afterwards.
+        HandleDiff(
+            final Map<Integer, HandleValue> recordOld,
+            final Map<Integer, HandleValue> recordNew
+        ) throws PidUpdateException {
             for (Entry<Integer, HandleValue> old : recordOld.entrySet()) {
                 boolean wasRemoved = !recordNew.containsKey(old.getKey());
                 if (wasRemoved) {
+                    // if a row in the record is not available anymore, we need to delete it
                     toRemove.add(old.getValue());
                 } else {
+                    // otherwise, we should go and update it.
+                    // we could also check for equality, but this is the safe and easy way.
+                    // (the handlevalue classes can be complicated and we'd have to check their
+                    // equality implementation)
                     toUpdate.add(recordNew.get(old.getKey()));
                 }
             }
             for (Entry<Integer, HandleValue> e : recordNew.entrySet()) {
                 boolean isNew = !recordOld.containsKey(e.getKey());
                 if (isNew) {
+                    // if there is a record which is not in the oldRecord, we need to add it.
                     toAdd.add(e.getValue());
                 }
             }

--- a/src/main/java/edu/kit/datamanager/pit/pidsystem/impl/HandleProtocolAdapter.java
+++ b/src/main/java/edu/kit/datamanager/pit/pidsystem/impl/HandleProtocolAdapter.java
@@ -15,8 +15,8 @@ import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.annotation.PostConstruct;
-import javax.validation.constraints.NotNull;
+import jakarta.annotation.PostConstruct;
+import jakarta.validation.constraints.NotNull;
 
 import org.apache.commons.lang3.stream.Streams;
 import org.slf4j.Logger;

--- a/src/main/java/edu/kit/datamanager/pit/pidsystem/impl/local/PidDatabaseObject.java
+++ b/src/main/java/edu/kit/datamanager/pit/pidsystem/impl/local/PidDatabaseObject.java
@@ -5,11 +5,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.persistence.Column;
-import javax.persistence.ElementCollection;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
 
 import edu.kit.datamanager.pit.domain.PIDRecord;
 import edu.kit.datamanager.pit.domain.PIDRecordEntry;
@@ -39,7 +39,7 @@ public class PidDatabaseObject {
      * an issue for mid-to-large records. We need to increase the length of stings
      * in this case:
      * 
-     * int javax.persistence.Column.length() (Optional) The column length. (Applies
+     * int jakarta.xpersistence.Column.length() (Optional) The column length. (Applies
      * only if a string-valued column is used.) Default: 255
      * 
      * The h2 database we use for testing has a CHARACTER VARYING limit of

--- a/src/main/java/edu/kit/datamanager/pit/web/ITypingRestResource.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/ITypingRestResource.java
@@ -245,11 +245,9 @@ public interface ITypingRestResource {
     @GetMapping(path = "known-pid/**")
     public ResponseEntity<KnownPid> findByPid(
             final WebRequest request,
-            
             final HttpServletResponse response,
-            
             final UriComponentsBuilder uriBuilder
-     ) throws IOException;
+    ) throws IOException;
 
     /**
      * Returns all known PIDs, limited by the given page size and number.

--- a/src/main/java/edu/kit/datamanager/pit/web/ITypingRestResource.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/ITypingRestResource.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.springdoc.core.converters.models.PageableAsQueryParam;
 import org.springframework.http.MediaType;

--- a/src/main/java/edu/kit/datamanager/pit/web/ITypingRestResource.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/ITypingRestResource.java
@@ -73,7 +73,7 @@ public interface ITypingRestResource {
      * @throws IOException
      */
     @PostMapping(
-        path = "/pid/",
+        path = "pid/",
         consumes = {MediaType.APPLICATION_JSON_VALUE, SimplePidRecord.CONTENT_TYPE},
         produces = {MediaType.APPLICATION_JSON_VALUE, SimplePidRecord.CONTENT_TYPE}
     )
@@ -132,7 +132,7 @@ public interface ITypingRestResource {
      * @throws IOException
      */
     @PutMapping(
-        path = "/pid/**",
+        path = "pid/**",
         consumes = {MediaType.APPLICATION_JSON_VALUE, SimplePidRecord.CONTENT_TYPE},
         produces = {MediaType.APPLICATION_JSON_VALUE, SimplePidRecord.CONTENT_TYPE}
     )
@@ -181,7 +181,7 @@ public interface ITypingRestResource {
      * @throws IOException
      */
     @GetMapping(
-        path = "/pid/**",
+        path = "pid/**",
         produces = {MediaType.APPLICATION_JSON_VALUE, SimplePidRecord.CONTENT_TYPE}
     )
     @Operation(summary = "Get the record of the given PID.", description = "Get the record to the given PID, if it exists. No validation is performed by default.")
@@ -242,7 +242,7 @@ public interface ITypingRestResource {
                 @ApiResponse(responseCode = "500", description = "Server error. See body for details.", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
         }
     )
-    @GetMapping(path = "/known-pid/**")
+    @GetMapping(path = "known-pid/**")
     public ResponseEntity<KnownPid> findByPid(
             final WebRequest request,
             
@@ -286,7 +286,7 @@ public interface ITypingRestResource {
             @ApiResponse(responseCode = "500", description = "Server error. See body for details.", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
         }
     )
-    @GetMapping(path = "/known-pid")
+    @GetMapping(path = "known-pid")
     @PageableAsQueryParam
     public ResponseEntity<List<KnownPid>> findAll(
             @Parameter(name = "created_after", description = "The UTC time of the earliest creation timestamp of a returned PID.", required = false)
@@ -346,7 +346,7 @@ public interface ITypingRestResource {
             @ApiResponse(responseCode = "500", description = "Server error. See body for details.", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
         }
     )
-    @GetMapping(path = "/known-pid", produces={"application/tabulator+json"}, headers = "Accept=application/tabulator+json")
+    @GetMapping(path = "known-pid", produces={"application/tabulator+json"}, headers = "Accept=application/tabulator+json")
     @PageableAsQueryParam
     public ResponseEntity<TabulatorPaginationFormat<KnownPid>> findAllForTabular(
             @Parameter(name = "created_after", description = "The UTC time of the earliest creation timestamp of a returned PID.", required = false)

--- a/src/main/java/edu/kit/datamanager/pit/web/impl/TypingRESTResourceImpl.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/impl/TypingRESTResourceImpl.java
@@ -29,7 +29,7 @@ import edu.kit.datamanager.util.AuthenticationHelper;
 import edu.kit.datamanager.util.ControllerUtils;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang3.stream.Streams;
 import org.apache.http.client.cache.HeaderConstants;

--- a/src/test/java/edu/kit/datamanager/pit/cli/CliTaskBootstrapTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/cli/CliTaskBootstrapTest.java
@@ -30,7 +30,7 @@ import edu.kit.datamanager.pit.pidlog.KnownPidsDao;
     locations = "/test/application-test.properties"
 )
 @ActiveProfiles("test")
-public class CliTaskBootstrapTest {
+class CliTaskBootstrapTest {
 
     @Autowired
     ConfigurableApplicationContext context;

--- a/src/test/java/edu/kit/datamanager/pit/cli/CliTaskWriteFileTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/cli/CliTaskWriteFileTest.java
@@ -8,7 +8,7 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
-public class CliTaskWriteFileTest {
+class CliTaskWriteFileTest {
     @Test
     void testCreateFilename() {
         Stream<String> pids = Stream.of("pid1", "pid2");

--- a/src/test/java/edu/kit/datamanager/pit/configuration/HandleProtocolSetupTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/configuration/HandleProtocolSetupTest.java
@@ -32,7 +32,7 @@ import edu.kit.datamanager.pit.pidsystem.impl.InMemoryIdentifierSystem;
     }
 )
 @ActiveProfiles("test")
-public class HandleProtocolSetupTest {
+class HandleProtocolSetupTest {
 
     @Autowired
     private ApplicationContext app;

--- a/src/test/java/edu/kit/datamanager/pit/configuration/InMemorySetupTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/configuration/InMemorySetupTest.java
@@ -19,7 +19,7 @@ import edu.kit.datamanager.pit.pidsystem.impl.InMemoryIdentifierSystem;
 @SpringBootTest
 @TestPropertySource("/test/application-test.properties")
 @ActiveProfiles("test")
-public class InMemorySetupTest {
+class InMemorySetupTest {
 
     @Autowired
     ApplicationContext app;

--- a/src/test/java/edu/kit/datamanager/pit/configuration/PidGenerationPropertiesTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/configuration/PidGenerationPropertiesTest.java
@@ -14,7 +14,7 @@ import edu.kit.datamanager.pit.configuration.PidGenerationProperties.Mode;
 import edu.kit.datamanager.pit.pidgeneration.PidSuffixGenerator;
 import edu.kit.datamanager.pit.pidgeneration.generators.HexChunksGeneratorTest;
 
-public class PidGenerationPropertiesTest {
+class PidGenerationPropertiesTest {
 
     /**
      * Makes assertions on the default PIDs. If this test breaks, we break the

--- a/src/test/java/edu/kit/datamanager/pit/domain/OperationsTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/domain/OperationsTest.java
@@ -21,7 +21,7 @@ import edu.kit.datamanager.pit.web.ApiMockUtils;
 // Set the in-memory implementation
 @TestPropertySource("/test/application-test.properties")
 @ActiveProfiles("test")
-public class OperationsTest {
+class OperationsTest {
 
     public static final String VALID_DATE = "2021-12-21T17:36:09.541+00:00";
     public static final String TYPE_PROFILE = "21.T11148/076759916209e5d62bd5";

--- a/src/test/java/edu/kit/datamanager/pit/domain/PIDRecordTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/domain/PIDRecordTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
  * Test Ensure the Entry of Insertion And Extraction of the class
  */
 
-public class PIDRecordTest {
+class PIDRecordTest {
     private static final String PID = "fake/pid/42";
 
     @Test

--- a/src/test/java/edu/kit/datamanager/pit/domain/SimplePidRecordTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/domain/SimplePidRecordTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-public class SimplePidRecordTest {
+class SimplePidRecordTest {
     @Test
     void testContentTypeConstant() {
         assertTrue(SimplePidRecord.CONTENT_TYPE.contains(SimplePidRecord.CONTENT_TYPE_PURE));

--- a/src/test/java/edu/kit/datamanager/pit/domain/TypeDefinitionTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/domain/TypeDefinitionTest.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Disabled("Does not work yet due to the complexity of the TypeDefinition implementation. See TODO below.")
-public class TypeDefinitionTest {
+class TypeDefinitionTest {
 
     @Test
     // TODO We should change the domain model so this or similar tests will run.

--- a/src/test/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticRepositoryTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticRepositoryTest.java
@@ -27,7 +27,7 @@ import edu.kit.datamanager.pit.web.ApiMockUtils;
 )
 @ActiveProfiles({"test", "elastic"})
 @Disabled("We need an instance of elasticsearch for these tests")
-public class PidRecordElasticRepositoryTest {
+class PidRecordElasticRepositoryTest {
 
     @Autowired
     private PidRecordElasticRepository dao;
@@ -36,7 +36,7 @@ public class PidRecordElasticRepositoryTest {
     private ITypingService typingService;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         dao.deleteAll();
     }
 

--- a/src/test/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticWrapperTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/elasticsearch/PidRecordElasticWrapperTest.java
@@ -19,7 +19,7 @@ import edu.kit.datamanager.pit.web.ApiMockUtils;
 // Set the in-memory implementation
 @TestPropertySource("/test/application-test.properties")
 @ActiveProfiles("test")
-public class PidRecordElasticWrapperTest {
+class PidRecordElasticWrapperTest {
 
     @Autowired
     ITypingService typingService;

--- a/src/test/java/edu/kit/datamanager/pit/pidgeneration/generators/PidSuffixGenLowerCaseTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/pidgeneration/generators/PidSuffixGenLowerCaseTest.java
@@ -9,7 +9,7 @@ import edu.kit.datamanager.pit.pidgeneration.PidSuffix;
 import edu.kit.datamanager.pit.pidgeneration.PidSuffixGenConstant;
 import edu.kit.datamanager.pit.pidgeneration.PidSuffixGenerator;
 
-public class PidSuffixGenLowerCaseTest {
+class PidSuffixGenLowerCaseTest {
     @Test
     void makesLowerCase() {
         PidSuffixGenerator cGen = new PidSuffixGenConstant();

--- a/src/test/java/edu/kit/datamanager/pit/pidgeneration/generators/PidSuffixGenPrefixedTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/pidgeneration/generators/PidSuffixGenPrefixedTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import edu.kit.datamanager.pit.pidgeneration.PidSuffixGenConstant;
 import edu.kit.datamanager.pit.pidgeneration.PidSuffixGenerator;
 
-public class PidSuffixGenPrefixedTest {
+class PidSuffixGenPrefixedTest {
     @Test
     void makesPrefixes() {
         PidSuffixGenerator c = new PidSuffixGenConstant();

--- a/src/test/java/edu/kit/datamanager/pit/pidgeneration/generators/PidSuffixGenUpperCaseTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/pidgeneration/generators/PidSuffixGenUpperCaseTest.java
@@ -9,7 +9,7 @@ import edu.kit.datamanager.pit.pidgeneration.PidSuffix;
 import edu.kit.datamanager.pit.pidgeneration.PidSuffixGenConstant;
 import edu.kit.datamanager.pit.pidgeneration.PidSuffixGenerator;
 
-public class PidSuffixGenUpperCaseTest {
+class PidSuffixGenUpperCaseTest {
     @Test
     void makesUpperCase() {
         PidSuffixGenerator cGen = new PidSuffixGenConstant();

--- a/src/test/java/edu/kit/datamanager/pit/pidgeneration/generators/PidSuffixGenUuid4Test.java
+++ b/src/test/java/edu/kit/datamanager/pit/pidgeneration/generators/PidSuffixGenUuid4Test.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import edu.kit.datamanager.pit.pidgeneration.PidSuffix;
 import edu.kit.datamanager.pit.pidgeneration.PidSuffixGenerator;
 
-public class PidSuffixGenUuid4Test {
+class PidSuffixGenUuid4Test {
     @Test
     void generatesUUID() {
         PidSuffixGenerator g = new PidSuffixGenUuid4();

--- a/src/test/java/edu/kit/datamanager/pit/pidlog/KnownPidTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/pidlog/KnownPidTest.java
@@ -8,7 +8,7 @@ import java.time.temporal.ChronoUnit;
 
 import org.junit.jupiter.api.Test;
 
-public class KnownPidTest {
+class KnownPidTest {
 
     private static final Instant NOW = Instant.now().truncatedTo(ChronoUnit.MILLIS);
     private static final Instant LATER = NOW.plus(1, ChronoUnit.DAYS).truncatedTo(ChronoUnit.MILLIS);
@@ -30,7 +30,7 @@ public class KnownPidTest {
     void testTrivialEquivalence() {
         KnownPid p = new KnownPid();
         assertEquals(p, p);
-        assertNotEquals(p, null); // pid is null
+        assertNotEquals(null, p);
 
         KnownPid b = new KnownPid();
         assertEquals(p, b);

--- a/src/test/java/edu/kit/datamanager/pit/pidlog/KnownPidsDaoTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/pidlog/KnownPidsDaoTest.java
@@ -1,10 +1,8 @@
 package edu.kit.datamanager.pit.pidlog;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -97,15 +95,10 @@ public class KnownPidsDaoTest {
         long numOfAll = knownPidsDao.count();
         assertEquals(7, numOfAll);
         long num = knownPidsDao.countDistinctPidsByCreatedBetween(MIN, MAX);
+        long numInstantMinMax = knownPidsDao.countDistinctPidsByCreatedBetween(MIN, Instant.MAX);
+        assertEquals(num, numInstantMinMax);
         assertEquals(numOfAll, num);
-        // Seems like some component does not support Instant.MIN or Instant.MAX:
-        assertThrows(
-            DateTimeException.class,
-            () -> knownPidsDao.countDistinctPidsByCreatedBetween(Instant.MIN, MAX));
-        assertThrows(
-            DateTimeException.class,
-            () -> knownPidsDao.countDistinctPidsByCreatedBetween(MIN, Instant.MAX));
-        // It also does not support null:
+        // Seems like some component does not support null:
         num = knownPidsDao.countDistinctPidsByCreatedBetween(null, MAX);
         assertEquals(0, num);
         num = knownPidsDao.countDistinctPidsByCreatedBetween(MIN, null);

--- a/src/test/java/edu/kit/datamanager/pit/pidlog/KnownPidsDaoTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/pidlog/KnownPidsDaoTest.java
@@ -25,7 +25,7 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest
 @TestPropertySource("/test/application-test.properties")
 @ActiveProfiles("test")
-public class KnownPidsDaoTest {
+class KnownPidsDaoTest {
 
     @Autowired
     private KnownPidsDao knownPidsDao;
@@ -40,21 +40,21 @@ public class KnownPidsDaoTest {
     private static final Instant TOO_LATE = NOW.plus(2, ChronoUnit.DAYS).truncatedTo(ChronoUnit.MILLIS);
 
     @BeforeAll
-    public static void setUpClass() {
+    static void setUpClass() {
 
     }
 
     @AfterAll
-    public static void tearDownClass() {
+    static void tearDownClass() {
     }
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         prepareDataBase();
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
     }
 
     private void prepareDataBase() {

--- a/src/test/java/edu/kit/datamanager/pit/pidsystem/IIdentifierSystemWriteTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/pidsystem/IIdentifierSystemWriteTest.java
@@ -35,7 +35,7 @@ import edu.kit.datamanager.pit.pidsystem.impl.local.LocalPidSystem;
     properties = "pit.pidsystem.implementation=LOCAL"
 )
 @ActiveProfiles("test")
-public class IIdentifierSystemWriteTest {
+class IIdentifierSystemWriteTest {
 
     @Autowired
     private LocalPidSystem localPidSystem;

--- a/src/test/java/edu/kit/datamanager/pit/pidsystem/impl/HandleProtocolAdapterTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/pidsystem/impl/HandleProtocolAdapterTest.java
@@ -1,0 +1,80 @@
+package edu.kit.datamanager.pit.pidsystem.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import edu.kit.datamanager.pit.pidsystem.impl.HandleProtocolAdapter.HandleDiff;
+import net.handle.hdllib.HandleValue;
+
+public class HandleProtocolAdapterTest {
+    @Test
+    void testDiffOldRecordEmpty() {
+        Map<Integer, HandleValue> oldRecord = new HashMap<>();
+        Map<Integer, HandleValue> newRecord = new HashMap<>();
+        addSomeHandleValue(newRecord, 1);
+        addSomeHandleValue(newRecord, 2);
+        addSomeHandleValue(newRecord, 100);
+        HandleDiff diff = new HandleDiff(oldRecord, newRecord);
+        assertEquals(0, diff.removed().length);
+        assertEquals(0, diff.updated().length);
+        assertEquals(newRecord.size(), diff.added().length);
+    }
+
+    @Test
+    void testDiffNewRecordEmpty() {
+        Map<Integer, HandleValue> oldRecord = new HashMap<>();
+        addSomeHandleValue(oldRecord, 1);
+        addSomeHandleValue(oldRecord, 2);
+        addSomeHandleValue(oldRecord, 100);
+        Map<Integer, HandleValue> newRecord = new HashMap<>();
+        HandleDiff diff = new HandleDiff(oldRecord, newRecord);
+        assertEquals(oldRecord.size(), diff.removed().length);
+        assertEquals(0, diff.updated().length);
+        assertEquals(0, diff.added().length);
+    }
+
+    @Test
+    void testDiffAllUpdated() {
+        Map<Integer, HandleValue> oldRecord = new HashMap<>();
+        addSomeHandleValue(oldRecord, 1);
+        addSomeHandleValue(oldRecord, 2);
+        addSomeHandleValue(oldRecord, 100);
+        Map<Integer, HandleValue> newRecord = new HashMap<>();
+        addSomeHandleValue(newRecord, 1);
+        addSomeHandleValue(newRecord, 2);
+        addSomeHandleValue(newRecord, 100);
+
+        HandleDiff diff = new HandleDiff(oldRecord, newRecord);
+        assertEquals(0, diff.removed().length);
+        assertEquals(oldRecord.size(), diff.updated().length);
+        assertEquals(0, diff.added().length);
+    }
+
+    @Test
+    void testDiffOneOfEachChange() {
+        Map<Integer, HandleValue> oldRecord = new HashMap<>();
+        addSomeHandleValue(oldRecord, 1);
+        addSomeHandleValue(oldRecord, 2);
+        Map<Integer, HandleValue> newRecord = new HashMap<>();
+        // removed 1
+        addSomeHandleValue(newRecord, 2);  // potentially changed 2
+        addSomeHandleValue(newRecord, 100); // added 100
+
+        HandleDiff diff = new HandleDiff(oldRecord, newRecord);
+        assertEquals(1, diff.removed().length);
+        assertEquals(1, diff.updated().length);
+        assertEquals(1, diff.added().length);
+    }
+
+    private void addSomeHandleValue(Map<Integer, HandleValue> record, int index) {
+        record.put(index, getHandleValue(index));
+    }
+
+    private HandleValue getHandleValue(int index) {
+        return new HandleValue(index, "", "");
+    }
+}

--- a/src/test/java/edu/kit/datamanager/pit/pidsystem/impl/HandleProtocolAdapterTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/pidsystem/impl/HandleProtocolAdapterTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import edu.kit.datamanager.pit.pidsystem.impl.HandleProtocolAdapter.HandleDiff;
 import net.handle.hdllib.HandleValue;
 
-public class HandleProtocolAdapterTest {
+class HandleProtocolAdapterTest {
     @Test
     void testDiffOldRecordEmpty() {
         Map<Integer, HandleValue> oldRecord = new HashMap<>();

--- a/src/test/java/edu/kit/datamanager/pit/pidsystem/impl/InMemoryIdentifierSystemTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/pidsystem/impl/InMemoryIdentifierSystemTest.java
@@ -14,7 +14,7 @@ import edu.kit.datamanager.pit.common.InvalidConfigException;
 import edu.kit.datamanager.pit.domain.PIDRecord;
 import edu.kit.datamanager.pit.domain.TypeDefinition;
 
-public class InMemoryIdentifierSystemTest {
+class InMemoryIdentifierSystemTest {
 
     private InMemoryIdentifierSystem sys;
     private TypeDefinition profile;
@@ -23,7 +23,7 @@ public class InMemoryIdentifierSystemTest {
     private TypeDefinition t3;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         this.sys = new InMemoryIdentifierSystem();
         this.t1 = new TypeDefinition();
         this.t1.setIdentifier("attribute1");

--- a/src/test/java/edu/kit/datamanager/pit/pidsystem/impl/local/LocalPidSystemTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/pidsystem/impl/local/LocalPidSystemTest.java
@@ -39,7 +39,7 @@ import edu.kit.datamanager.pit.pidsystem.IIdentifierSystemQueryTest;
     properties = "pit.pidsystem.implementation=LOCAL"
 )
 @ActiveProfiles("test")
-public class LocalPidSystemTest {
+class LocalPidSystemTest {
     IIdentifierSystemQueryTest systemTests = new IIdentifierSystemQueryTest();
     
     @Autowired

--- a/src/test/java/edu/kit/datamanager/pit/pidsystem/impl/local/PidDatabaseObjectDaoTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/pidsystem/impl/local/PidDatabaseObjectDaoTest.java
@@ -26,7 +26,7 @@ class PidDatabaseObjectDaoTest {
     private PidDatabaseObjectDao dao;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         PidDatabaseObject a = new PidDatabaseObject("first", "first");
         PidDatabaseObject b = new PidDatabaseObject("second", "second");
         PidDatabaseObject c = new PidDatabaseObject("second", "third");

--- a/src/test/java/edu/kit/datamanager/pit/pidsystem/impl/local/PidDatabaseObjectTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/pidsystem/impl/local/PidDatabaseObjectTest.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.core.JacksonException;
 import edu.kit.datamanager.pit.domain.PIDRecord;
 import edu.kit.datamanager.pit.web.ApiMockUtils;
 
-public class PidDatabaseObjectTest {
+class PidDatabaseObjectTest {
     @Test
     void testConversion() throws JacksonException {
         PIDRecord original = ApiMockUtils.getSomePidRecordInstance();

--- a/src/test/java/edu/kit/datamanager/pit/pitservice/impl/TypingServiceTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/pitservice/impl/TypingServiceTest.java
@@ -16,7 +16,7 @@ import edu.kit.datamanager.pit.pitservice.IValidationStrategy;
 @SpringBootTest
 @TestPropertySource("/test/application-test.properties")
 @ActiveProfiles("test")
-public class TypingServiceTest {
+class TypingServiceTest {
 
     @Autowired
     private ApplicationContext app;

--- a/src/test/java/edu/kit/datamanager/pit/typeregistry/impl/TypeRegistryTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/typeregistry/impl/TypeRegistryTest.java
@@ -18,7 +18,7 @@ import org.springframework.test.context.TestPropertySource;
 // Set the in-memory implementation
 @TestPropertySource(locations = "/test/application-test.properties", properties = "pit.pidsystem.implementation = LOCAL")
 @ActiveProfiles("test")
-public class TypeRegistryTest {
+class TypeRegistryTest {
 
     @Autowired
     TypeRegistry typeRegistry;

--- a/src/test/java/edu/kit/datamanager/pit/web/ApiMockUtils.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/ApiMockUtils.java
@@ -82,7 +82,7 @@ public class ApiMockUtils {
         Instant modifiedBefore,
         Optional<Pageable> pageable
     ) throws Exception {
-        MockHttpServletRequestBuilder request =  get("/api/v1/pit/known-pid/");
+        MockHttpServletRequestBuilder request =  get("/api/v1/pit/known-pid");
         if (pageable.isPresent()) {
             request.param("page", String.valueOf(pageable.get().getPageNumber()));
             request.param("size", String.valueOf(pageable.get().getPageSize()));
@@ -117,7 +117,7 @@ public class ApiMockUtils {
         Instant modifiedBefore,
         Optional<Pageable> pageable
     ) throws Exception {
-        MockHttpServletRequestBuilder request =  get("/api/v1/pit/known-pid/");
+        MockHttpServletRequestBuilder request =  get("/api/v1/pit/known-pid");
         if (pageable.isPresent()) {
             request.param("page", String.valueOf(pageable.get().getPageNumber()));
             request.param("size", String.valueOf(pageable.get().getPageSize()));

--- a/src/test/java/edu/kit/datamanager/pit/web/ApiMockUtils.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/ApiMockUtils.java
@@ -11,6 +11,7 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.ResultMatcher;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -369,14 +370,13 @@ public class ApiMockUtils {
         return registerRecordAndGetMvcResult(mockMvc, body, bodyContentType, acceptContentType, MockMvcResultMatchers.status().isCreated());
     }
 
-    public static MvcResult registerRecordAndGetMvcResult(
+    public static ResultActions registerRecordAndGetResultActions(
         MockMvc mockMvc,
         String body,
         String bodyContentType,
-        String acceptContentType,
-        ResultMatcher expectHttpCode) throws Exception
-    {
-        MockHttpServletRequestBuilder request = post("/api/v1/pit/pid/")
+        String acceptContentType
+    ) throws Exception {
+            MockHttpServletRequestBuilder request = post("/api/v1/pit/pid/")
             .contentType(MediaType.APPLICATION_JSON)
             .characterEncoding("utf-8")
             .content(body);
@@ -392,12 +392,26 @@ public class ApiMockUtils {
         } else {
             request = request.contentType(MediaType.APPLICATION_JSON);
         }
-        MvcResult created = mockMvc
+        return mockMvc
             .perform(request)
-            .andDo(MockMvcResultHandlers.print())
+            .andDo(MockMvcResultHandlers.print());
+        }
+
+    public static MvcResult registerRecordAndGetMvcResult(
+        MockMvc mockMvc,
+        String body,
+        String bodyContentType,
+        String acceptContentType,
+        ResultMatcher expectHttpCode) throws Exception
+    {
+        return registerRecordAndGetResultActions(
+            mockMvc,
+            body,
+            bodyContentType,
+            acceptContentType
+        )
             .andExpect(expectHttpCode)
             .andReturn();
-        return created;
     }
 
     public static PIDRecord clone(PIDRecord original) throws JsonMappingException, JsonProcessingException {

--- a/src/test/java/edu/kit/datamanager/pit/web/CustomPidsTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/CustomPidsTest.java
@@ -42,7 +42,7 @@ class CustomPidsTest {
     private MockMvc mockMvc;
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.webApplicationContext).build();
         this.props.setCustomClientPidsEnabled(true);
     }

--- a/src/test/java/edu/kit/datamanager/pit/web/EtagTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/EtagTest.java
@@ -50,7 +50,7 @@ class EtagTest {
      */
     @BeforeEach
     @Test
-    public void setup() throws Exception {
+    void setup() throws Exception {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.webApplicationContext).build();
 
         MockHttpServletResponse response = ApiMockUtils.registerSomeRecordAndReturnMvcResult(this.mockMvc).getResponse();

--- a/src/test/java/edu/kit/datamanager/pit/web/ExplicitValidationParametersTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/ExplicitValidationParametersTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import jakarta.xservlet.ServletContext;
+import jakarta.servlet.ServletContext;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/src/test/java/edu/kit/datamanager/pit/web/ExplicitValidationParametersTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/ExplicitValidationParametersTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import javax.servlet.ServletContext;
+import jakarta.xservlet.ServletContext;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/src/test/java/edu/kit/datamanager/pit/web/ExplicitValidationParametersTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/ExplicitValidationParametersTest.java
@@ -67,7 +67,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 // Set the in-memory implementation
 @TestPropertySource("/test/application-test.properties")
 @ActiveProfiles("test")
-public class ExplicitValidationParametersTest {
+class ExplicitValidationParametersTest {
 
     static final String EMPTY_RECORD = "{\"pid\": null, \"entries\": {}}";
     static final String RECORD = "{\"entries\":{\"21.T11148/076759916209e5d62bd5\":[{\"key\":\"21.T11148/076759916209e5d62bd5\",\"name\":\"kernelInformationProfile\",\"value\":\"21.T11148/301c6f04763a16f0f72a\"}],\"21.T11148/397d831aa3a9d18eb52c\":[{\"key\":\"21.T11148/397d831aa3a9d18eb52c\",\"name\":\"dateModified\",\"value\":\"2021-12-21T17:36:09.541+00:00\"}],\"21.T11148/8074aed799118ac263ad\":[{\"key\":\"21.T11148/8074aed799118ac263ad\",\"name\":\"digitalObjectPolicy\",\"value\":\"21.T11148/37d0f4689c6ea3301787\"}],\"21.T11148/92e200311a56800b3e47\":[{\"key\":\"21.T11148/92e200311a56800b3e47\",\"name\":\"etag\",\"value\":\"{ \\\"sha256sum\\\": \\\"sha256 c50624fd5ddd2b9652b72e2d2eabcb31a54b777718ab6fb7e44b582c20239a7c\\\" }\"}],\"21.T11148/aafd5fb4c7222e2d950a\":[{\"key\":\"21.T11148/aafd5fb4c7222e2d950a\",\"name\":\"dateCreated\",\"value\":\"2021-12-21T17:36:09.541+00:00\"}],\"21.T11148/b8457812905b83046284\":[{\"key\":\"21.T11148/b8457812905b83046284\",\"name\":\"digitalObjectLocation\",\"value\":\"https://test.repo/file001\"}],\"21.T11148/c692273deb2772da307f\":[{\"key\":\"21.T11148/c692273deb2772da307f\",\"name\":\"version\",\"value\":\"1.0.0\"}],\"21.T11148/c83481d4bf467110e7c9\":[{\"key\":\"21.T11148/c83481d4bf467110e7c9\",\"name\":\"digitalObjectType\",\"value\":\"21.T11148/ManuscriptPage\"}]},\"pid\":\"unregistered-18622\"}";
@@ -93,14 +93,14 @@ public class ExplicitValidationParametersTest {
     private InMemoryIdentifierSystem inMemory;
     
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.webApplicationContext).build();
         this.knownPidsDao.deleteAll();
         this.typingService.setValidationStrategy(this.appProps.defaultValidationStrategy());
     }
 
     @Test
-    public void checkTestSetup() {
+    void checkTestSetup() {
         assertNotNull(this.mockMvc);
         assertNotNull(this.webApplicationContext);
         assertNotNull(this.inMemory);
@@ -115,7 +115,7 @@ public class ExplicitValidationParametersTest {
     }
 
     @Test
-    public void testCreateEmptyRecord() throws Exception {
+    void testCreateEmptyRecord() throws Exception {
         this.mockMvc
             .perform(
                 post("/api/v1/pit/pid/")
@@ -134,7 +134,7 @@ public class ExplicitValidationParametersTest {
 
     @Test
     @DisplayName("Testing PID Records with usual/larger size, without validation. Should return 200 instead of 201 with dryrun.")
-    public void testExtensiveRecordDryRun() throws Exception {
+    void testExtensiveRecordDryRun() throws Exception {
         // create mockup of a large record. It contains non-registered PIDs and can not be validated.
         this.typingService.setValidationStrategy(new NoValidationStrategy());
         // as we use an in-memory data structure, lets not make it too large.
@@ -162,7 +162,7 @@ public class ExplicitValidationParametersTest {
 
     @Test
     @DisplayName("Testing PID Records with usual/larger size, without validation. Should return 201, as dryrun is false.")
-    public void testExtensiveRecordWithoutDryRun() throws Exception {
+    void testExtensiveRecordWithoutDryRun() throws Exception {
         // create mockup of a large record. It contains non-registered PIDs and can not be validated.
         this.typingService.setValidationStrategy(new NoValidationStrategy());
         // as we use an in-memory data structure, lets not make it too large.
@@ -189,7 +189,7 @@ public class ExplicitValidationParametersTest {
     }
 
     @Test
-    public void testNontypeRecord() throws Exception {
+    void testNontypeRecord() throws Exception {
         PIDRecord r = new PIDRecord();
         r.addEntry("unregisteredType", "for Testing", "hello");
         this.mockMvc
@@ -209,7 +209,7 @@ public class ExplicitValidationParametersTest {
     }
 
     @Test
-    public void testInvalidRecordWithProfile() throws Exception {
+    void testInvalidRecordWithProfile() throws Exception {
         PIDRecord r = new PIDRecord();
         r.addEntry("21.T11148/076759916209e5d62bd5", "for Testing", "21.T11148/301c6f04763a16f0f72a");
         this.mockMvc
@@ -230,7 +230,7 @@ public class ExplicitValidationParametersTest {
 
     @Test
     @DisplayName("Resolve a PID known to be valid, with explicit validation.")
-    public void testResolvingValidRecordWithValidation() throws Exception {
+    void testResolvingValidRecordWithValidation() throws Exception {
         this.testExtensiveRecordWithoutDryRun();
         assertEquals(1, knownPidsDao.count());
         String validPid = knownPidsDao.findAll().iterator().next().getPid();
@@ -246,7 +246,7 @@ public class ExplicitValidationParametersTest {
 
     @Test
     @DisplayName("Resolve a PID known to be invalid, with explicit validation.")
-    public void testResolvingValidRecordWithValidationFail() throws Exception {
+    void testResolvingValidRecordWithValidationFail() throws Exception {
         // note: this test disables validation...
         this.testExtensiveRecordWithoutDryRun();
         assertEquals(1, knownPidsDao.count());

--- a/src/test/java/edu/kit/datamanager/pit/web/ExplicitValidationParametersTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/ExplicitValidationParametersTest.java
@@ -42,9 +42,10 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
+import org.hamcrest.Matchers;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-
 
 /**
  * This is a dedicated test for the validation/dryrun parameters, available for the REST interface.
@@ -266,7 +267,8 @@ public class ExplicitValidationParametersTest {
             )
             .andDo(MockMvcResultHandlers.print())
             .andExpect(MockMvcResultMatchers.status().isBadRequest())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.detail", Matchers.containsString("Missing mandatory types: [")))
             .andReturn();
-        assertTrue(0 < result.getResponse().getErrorMessage().length());
+        assertTrue(0 < result.getResponse().getContentAsString().length());
     }
 }

--- a/src/test/java/edu/kit/datamanager/pit/web/ITypingRestResourceTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/ITypingRestResourceTest.java
@@ -29,7 +29,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 // Set the in-memory implementation
 @TestPropertySource("/test/application-test.properties")
 @ActiveProfiles("test")
-public class ITypingRestResourceTest {
+class ITypingRestResourceTest {
 
     @Autowired
     private WebApplicationContext webApplicationContext;
@@ -37,7 +37,7 @@ public class ITypingRestResourceTest {
     private MockMvc mockMvc;
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         this.mockMvc = MockMvcBuilders
                 .webAppContextSetup(this.webApplicationContext)
                 .build();

--- a/src/test/java/edu/kit/datamanager/pit/web/RestWithHandleProtocolTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/RestWithHandleProtocolTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
-import jakarta.xservlet.ServletContext;
+import jakarta.servlet.ServletContext;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/src/test/java/edu/kit/datamanager/pit/web/RestWithHandleProtocolTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/RestWithHandleProtocolTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
-import javax.servlet.ServletContext;
+import jakarta.xservlet.ServletContext;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/src/test/java/edu/kit/datamanager/pit/web/RestWithHandleProtocolTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/RestWithHandleProtocolTest.java
@@ -43,7 +43,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @TestPropertySource("/test/application-test.properties")
 // TODO why a testing profile?
 @ActiveProfiles("test")
-public class RestWithHandleProtocolTest {
+class RestWithHandleProtocolTest {
 
     @Autowired
     private WebApplicationContext webApplicationContext;
@@ -55,13 +55,13 @@ public class RestWithHandleProtocolTest {
     static final String pid = "21.T11148/076759916209e5d62bd5";
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.webApplicationContext).build();
         this.mapper = this.webApplicationContext.getBean("OBJECT_MAPPER_BEAN", ObjectMapper.class);
     }
 
     @Test
-    public void checkTestSetup() {
+    void checkTestSetup() {
         assertNotNull(this.mockMvc);
         assertNotNull(this.webApplicationContext);
         ServletContext servletContext = webApplicationContext.getServletContext();
@@ -76,7 +76,7 @@ public class RestWithHandleProtocolTest {
     }
 
     @Test
-    public void resolveSomething() throws Exception {
+    void resolveSomething() throws Exception {
         MvcResult resolved = this.mockMvc
             .perform(
                 get("/api/v1/pit/pid/".concat(pid))

--- a/src/test/java/edu/kit/datamanager/pit/web/RestWithInMemoryTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/RestWithInMemoryTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import jakarta.xservlet.ServletContext;
+import jakarta.servlet.ServletContext;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/test/java/edu/kit/datamanager/pit/web/RestWithInMemoryTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/RestWithInMemoryTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import javax.servlet.ServletContext;
+import jakarta.xservlet.ServletContext;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/test/java/edu/kit/datamanager/pit/web/RestWithInMemoryTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/RestWithInMemoryTest.java
@@ -67,7 +67,7 @@ import java.util.Optional;
 @TestPropertySource("/test/application-test.properties")
 // TODO why a testing profile?
 @ActiveProfiles("test")
-public class RestWithInMemoryTest {
+class RestWithInMemoryTest {
 
     static final String EMPTY_RECORD = "{\"pid\": null, \"entries\": {}}";
     static final String RECORD = "{\"entries\":{\"21.T11148/076759916209e5d62bd5\":[{\"key\":\"21.T11148/076759916209e5d62bd5\",\"name\":\"kernelInformationProfile\",\"value\":\"21.T11148/301c6f04763a16f0f72a\"}],\"21.T11148/397d831aa3a9d18eb52c\":[{\"key\":\"21.T11148/397d831aa3a9d18eb52c\",\"name\":\"dateModified\",\"value\":\"2021-12-21T17:36:09.541+00:00\"}],\"21.T11148/8074aed799118ac263ad\":[{\"key\":\"21.T11148/8074aed799118ac263ad\",\"name\":\"digitalObjectPolicy\",\"value\":\"21.T11148/37d0f4689c6ea3301787\"}],\"21.T11148/92e200311a56800b3e47\":[{\"key\":\"21.T11148/92e200311a56800b3e47\",\"name\":\"etag\",\"value\":\"{ \\\"sha256sum\\\": \\\"sha256 c50624fd5ddd2b9652b72e2d2eabcb31a54b777718ab6fb7e44b582c20239a7c\\\" }\"}],\"21.T11148/aafd5fb4c7222e2d950a\":[{\"key\":\"21.T11148/aafd5fb4c7222e2d950a\",\"name\":\"dateCreated\",\"value\":\"2021-12-21T17:36:09.541+00:00\"}],\"21.T11148/b8457812905b83046284\":[{\"key\":\"21.T11148/b8457812905b83046284\",\"name\":\"digitalObjectLocation\",\"value\":\"https://test.repo/file001\"}],\"21.T11148/c692273deb2772da307f\":[{\"key\":\"21.T11148/c692273deb2772da307f\",\"name\":\"version\",\"value\":\"1.0.0\"}],\"21.T11148/c83481d4bf467110e7c9\":[{\"key\":\"21.T11148/c83481d4bf467110e7c9\",\"name\":\"digitalObjectType\",\"value\":\"21.T11148/ManuscriptPage\"}]},\"pid\":\"unregistered-18622\"}";
@@ -96,7 +96,7 @@ public class RestWithInMemoryTest {
     private static final Instant TOMORROW = NOW.plus(1, ChronoUnit.DAYS).truncatedTo(ChronoUnit.MILLIS);
     
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.webApplicationContext).build();
         this.mapper = this.webApplicationContext.getBean("OBJECT_MAPPER_BEAN", ObjectMapper.class);
         this.knownPidsDao.deleteAll();
@@ -104,7 +104,7 @@ public class RestWithInMemoryTest {
     }
 
     @Test
-    public void checkTestSetup() {
+    void checkTestSetup() {
         assertNotNull(this.mockMvc);
         assertNotNull(this.webApplicationContext);
         ServletContext servletContext = webApplicationContext.getServletContext();
@@ -119,7 +119,7 @@ public class RestWithInMemoryTest {
     }
 
     @Test
-    public void testNotFound() throws Exception {
+    void testNotFound() throws Exception {
         this.mockMvc.perform(
                 get("/api/v1/pit/pid/prefix/pid")
             )
@@ -129,7 +129,7 @@ public class RestWithInMemoryTest {
     }
 
     @Test
-    public void testCreateEmptyRecord() throws Exception {
+    void testCreateEmptyRecord() throws Exception {
         this.mockMvc
             .perform(
                 post("/api/v1/pit/pid/")
@@ -147,7 +147,7 @@ public class RestWithInMemoryTest {
 
     @Test
     @DisplayName("Testing PID Records with usual/larger size, with the InMemory PID system.")
-    public void testExtensiveRecord() throws Exception {
+    void testExtensiveRecord() throws Exception {
         // create mockup of a large record. It contains non-registered PIDs and can not be validated.
         this.typingService.setValidationStrategy(new NoValidationStrategy());
         // as we use an in-memory data structure, lets not make it too large.
@@ -167,7 +167,7 @@ public class RestWithInMemoryTest {
     }
 
     @Test
-    public void testNontypeRecord() throws Exception {
+    void testNontypeRecord() throws Exception {
         PIDRecord r = new PIDRecord();
         r.addEntry("unregisteredType", "for Testing", "hello");
         this.mockMvc
@@ -186,7 +186,7 @@ public class RestWithInMemoryTest {
     }
 
     @Test
-    public void testInvalidRecordWithProfile() throws Exception {
+    void testInvalidRecordWithProfile() throws Exception {
         PIDRecord r = new PIDRecord();
         r.addEntry("21.T11148/076759916209e5d62bd5", "for Testing", "21.T11148/301c6f04763a16f0f72a");
         MvcResult result = this.mockMvc
@@ -209,7 +209,7 @@ public class RestWithInMemoryTest {
     }
 
     @Test
-    public void testCreateValidRecord() throws Exception {
+    void testCreateValidRecord() throws Exception {
         // test create
         PIDRecord createdRecord = ApiMockUtils.registerSomeRecord(this.mockMvc);
         String createdPid = createdRecord.getPid();
@@ -231,7 +231,7 @@ public class RestWithInMemoryTest {
     }
 
     @Test
-    public void testUpdateRecord() throws Exception {
+    void testUpdateRecord() throws Exception {
         PIDRecord original = ApiMockUtils.registerSomeRecord(this.mockMvc);
         PIDRecord modified = ApiMockUtils.clone(original);
         modified.getEntries().get("21.T11148/b8457812905b83046284").get(0).setValue("https://example.com/anotherUrlAsBefore");
@@ -240,7 +240,7 @@ public class RestWithInMemoryTest {
     }
 
     @Test
-    public void testIdPidRegisteredFails() throws Exception {
+    void testIdPidRegisteredFails() throws Exception {
         // Nothing is registered, our local storags contains no PIDs
         PIDRecord nonRegistered = mapper.readValue(RECORD, PIDRecord.class);
         boolean isRegistered = isPidRegistered(nonRegistered.getPid());
@@ -249,7 +249,7 @@ public class RestWithInMemoryTest {
     }
 
     @Test
-    public void testIsPidRecordRegisteredSucceeds() throws Exception {
+    void testIsPidRecordRegisteredSucceeds() throws Exception {
         PIDRecord existing = ApiMockUtils.registerSomeRecord(this.mockMvc);
         // We know a PID after we create one.
         assertEquals(1, this.knownPidsDao.count());

--- a/src/test/java/edu/kit/datamanager/pit/web/RestWithInMemoryTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/RestWithInMemoryTest.java
@@ -11,6 +11,7 @@ import jakarta.servlet.ServletContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -198,12 +199,13 @@ public class RestWithInMemoryTest {
             )
             .andDo(MockMvcResultHandlers.print())
             .andExpect(MockMvcResultMatchers.status().isBadRequest())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.detail", Matchers.containsString("Missing mandatory types: [")))
             .andReturn();
         
         // we store PIDs only if the PID was created successfully
         assertEquals(0, this.knownPidsDao.count());
         // assume error parsed from body
-        assertTrue(0 < result.getResponse().getErrorMessage().length());
+        assertTrue(0 < result.getResponse().getContentAsString().length());
     }
 
     @Test

--- a/src/test/java/edu/kit/datamanager/pit/web/RestWithLocalPidSystemTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/RestWithLocalPidSystemTest.java
@@ -69,7 +69,7 @@ import java.util.Optional;
     properties = "pit.pidsystem.implementation = LOCAL"
 )
 @ActiveProfiles("test")
-public class RestWithLocalPidSystemTest {
+class RestWithLocalPidSystemTest {
 
     static final String EMPTY_RECORD = "{\"pid\": null, \"entries\": {}}";
     static final String RECORD = "{\"entries\":{\"21.T11148/076759916209e5d62bd5\":[{\"key\":\"21.T11148/076759916209e5d62bd5\",\"name\":\"kernelInformationProfile\",\"value\":\"21.T11148/301c6f04763a16f0f72a\"}],\"21.T11148/397d831aa3a9d18eb52c\":[{\"key\":\"21.T11148/397d831aa3a9d18eb52c\",\"name\":\"dateModified\",\"value\":\"2021-12-21T17:36:09.541+00:00\"}],\"21.T11148/8074aed799118ac263ad\":[{\"key\":\"21.T11148/8074aed799118ac263ad\",\"name\":\"digitalObjectPolicy\",\"value\":\"21.T11148/37d0f4689c6ea3301787\"}],\"21.T11148/92e200311a56800b3e47\":[{\"key\":\"21.T11148/92e200311a56800b3e47\",\"name\":\"etag\",\"value\":\"{ \\\"sha256sum\\\": \\\"sha256 c50624fd5ddd2b9652b72e2d2eabcb31a54b777718ab6fb7e44b582c20239a7c\\\" }\"}],\"21.T11148/aafd5fb4c7222e2d950a\":[{\"key\":\"21.T11148/aafd5fb4c7222e2d950a\",\"name\":\"dateCreated\",\"value\":\"2021-12-21T17:36:09.541+00:00\"}],\"21.T11148/b8457812905b83046284\":[{\"key\":\"21.T11148/b8457812905b83046284\",\"name\":\"digitalObjectLocation\",\"value\":\"https://test.repo/file001\"}],\"21.T11148/c692273deb2772da307f\":[{\"key\":\"21.T11148/c692273deb2772da307f\",\"name\":\"version\",\"value\":\"1.0.0\"}],\"21.T11148/c83481d4bf467110e7c9\":[{\"key\":\"21.T11148/c83481d4bf467110e7c9\",\"name\":\"digitalObjectType\",\"value\":\"21.T11148/ManuscriptPage\"}]},\"pid\":\"unregistered-18622\"}";
@@ -98,7 +98,7 @@ public class RestWithLocalPidSystemTest {
     private static final Instant TOMORROW = NOW.plus(1, ChronoUnit.DAYS).truncatedTo(ChronoUnit.MILLIS);
     
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.webApplicationContext).build();
         this.mapper = this.webApplicationContext.getBean("OBJECT_MAPPER_BEAN", ObjectMapper.class);
         this.knownPidsDao.deleteAll();
@@ -106,7 +106,7 @@ public class RestWithLocalPidSystemTest {
     }
 
     @Test
-    public void checkTestSetup() {
+    void checkTestSetup() {
         assertNotNull(this.mockMvc);
         assertNotNull(this.webApplicationContext);
         ServletContext servletContext = webApplicationContext.getServletContext();
@@ -125,7 +125,7 @@ public class RestWithLocalPidSystemTest {
     }
 
     @Test
-    public void testNotFound() throws Exception {
+    void testNotFound() throws Exception {
         this.mockMvc.perform(
                 get("/api/v1/pit/pid/prefix/pid")
             )
@@ -135,7 +135,7 @@ public class RestWithLocalPidSystemTest {
     }
 
     @Test
-    public void testCreateEmptyRecord() throws Exception {
+    void testCreateEmptyRecord() throws Exception {
         this.mockMvc
             .perform(
                 post("/api/v1/pit/pid/")
@@ -154,7 +154,7 @@ public class RestWithLocalPidSystemTest {
     }
 
     @Test
-    public void testCreateValidRecord() throws Exception {
+    void testCreateValidRecord() throws Exception {
         // test create
         PIDRecord createdRecord = ApiMockUtils.registerSomeRecord(this.mockMvc);
         String createdPid = createdRecord.getPid();
@@ -177,7 +177,7 @@ public class RestWithLocalPidSystemTest {
 
     @Test
     @DisplayName("Testing PID Records with usual/larger size, with the Local PID system (in-memory db).")
-    public void testExtensiveRecord() throws Exception {
+    void testExtensiveRecord() throws Exception {
         // create mockup of a large record. It contains non-registered PIDs and can not be validated.
         this.typingService.setValidationStrategy(new NoValidationStrategy());
         // as we use an in-memory db for testing, lets not make it too large.
@@ -197,7 +197,7 @@ public class RestWithLocalPidSystemTest {
     }
 
     @Test
-    public void testUpdateRecord() throws Exception {
+    void testUpdateRecord() throws Exception {
         PIDRecord original = ApiMockUtils.registerSomeRecord(this.mockMvc);
         PIDRecord modified = ApiMockUtils.clone(original);
         modified.getEntries().get("21.T11148/b8457812905b83046284").get(0).setValue("https://example.com/anotherUrlAsBefore");
@@ -206,7 +206,7 @@ public class RestWithLocalPidSystemTest {
     }
 
     @Test
-    public void testIdPidRegisteredFails() throws Exception {
+    void testIdPidRegisteredFails() throws Exception {
         // Nothing is registered, our local storags contains no PIDs
         PIDRecord nonRegistered = mapper.readValue(RECORD, PIDRecord.class);
         boolean isRegistered = isPidRegistered(nonRegistered.getPid());
@@ -215,7 +215,7 @@ public class RestWithLocalPidSystemTest {
     }
 
     @Test
-    public void testIsPidRecordRegisteredSucceeds() throws Exception {
+    void testIsPidRecordRegisteredSucceeds() throws Exception {
         PIDRecord existing = ApiMockUtils.registerSomeRecord(this.mockMvc);
         // We know a PID after we create one.
         assertEquals(1, this.knownPidsDao.count());

--- a/src/test/java/edu/kit/datamanager/pit/web/RestWithLocalPidSystemTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/RestWithLocalPidSystemTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import jakarta.xservlet.ServletContext;
+import jakarta.servlet.ServletContext;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/src/test/java/edu/kit/datamanager/pit/web/RestWithLocalPidSystemTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/RestWithLocalPidSystemTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import javax.servlet.ServletContext;
+import jakarta.xservlet.ServletContext;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/src/test/java/edu/kit/datamanager/pit/web/SimpleJSONFormatTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/SimpleJSONFormatTest.java
@@ -36,7 +36,7 @@ class SimpleJSONFormatTest {
     private MockMvc mockMvc;
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.webApplicationContext).build();
     }
 

--- a/src/test/java/edu/kit/datamanager/pit/web/SimpleJSONFormatTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/SimpleJSONFormatTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.http.entity.ContentType;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -69,14 +70,15 @@ class SimpleJSONFormatTest {
     void testCreateWithUnsupportedAcceptType() throws Exception {
         SimplePidRecord input = new SimplePidRecord(ApiMockUtils.getSomePidRecordInstance());
         String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(input);
-        String responseBody = ApiMockUtils.registerRecord(
+        String detailMessage = "Acceptable representations: [" + ContentType.APPLICATION_JSON.getMimeType() + ", " + SimplePidRecord.CONTENT_TYPE + "].";
+        ApiMockUtils.registerRecordAndGetResultActions(
             mockMvc,
             requestBody,
             SimplePidRecord.CONTENT_TYPE,
-            ContentType.APPLICATION_SVG_XML.getMimeType(),
-            MockMvcResultMatchers.status().isNotAcceptable());
-        // Spring does not give a message in the body in this case.
-        assertTrue(responseBody.isBlank());
+            ContentType.APPLICATION_SVG_XML.getMimeType()
+        )
+            .andExpect(MockMvcResultMatchers.status().isNotAcceptable())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.detail", Matchers.is(detailMessage)));
     }
 
     /**
@@ -90,14 +92,15 @@ class SimpleJSONFormatTest {
     void testCreateWithUnsupportedContentType() throws Exception {
         SimplePidRecord input = new SimplePidRecord(ApiMockUtils.getSomePidRecordInstance());
         String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(input);
-        String responseBody = ApiMockUtils.registerRecord(
+        String detailMessage = "Content-Type '" + ContentType.APPLICATION_SVG_XML.getMimeType() + "' is not supported.";
+        ApiMockUtils.registerRecordAndGetResultActions(
             mockMvc,
             requestBody,
             ContentType.APPLICATION_SVG_XML.getMimeType(),
-            SimplePidRecord.CONTENT_TYPE,
-            MockMvcResultMatchers.status().isUnsupportedMediaType());
-        // Spring does not give a message in the body in this case.
-        assertTrue(responseBody.isBlank());
+            SimplePidRecord.CONTENT_TYPE
+        )
+            .andExpect(MockMvcResultMatchers.status().isUnsupportedMediaType())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.detail", Matchers.is(detailMessage)));
     }
 
     /**
@@ -111,14 +114,15 @@ class SimpleJSONFormatTest {
     void testCreateWithUnsupportedMediaTypes() throws Exception {
         SimplePidRecord input = new SimplePidRecord(ApiMockUtils.getSomePidRecordInstance());
         String requestBody = ApiMockUtils.getJsonMapper().writeValueAsString(input);
-        String responseBody = ApiMockUtils.registerRecord(
+        String detailMessage = "Content-Type '" + ContentType.APPLICATION_SVG_XML.getMimeType() + "' is not supported.";
+        ApiMockUtils.registerRecordAndGetResultActions(
             mockMvc,
             requestBody,
             ContentType.APPLICATION_SVG_XML.getMimeType(),
-            SimplePidRecord.CONTENT_TYPE,
-            MockMvcResultMatchers.status().isUnsupportedMediaType());
-        // Spring does not give a message in the body in this case.
-        assertTrue(responseBody.isBlank());
+            SimplePidRecord.CONTENT_TYPE
+        )
+            .andExpect(MockMvcResultMatchers.status().isUnsupportedMediaType())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.detail", Matchers.is(detailMessage)));
     }
 
     /**

--- a/src/test/java/edu/kit/datamanager/pit/web/TabulatorPaginationFormatTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/TabulatorPaginationFormatTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 
-public class TabulatorPaginationFormatTest {
+class TabulatorPaginationFormatTest {
     @Test
     void testConstructorAssignments() {
         List<String> list = new ArrayList<>();


### PR DESCRIPTION
Fixes #155 

- [x] fix deprecated stuff before upgrade, as far as possible
- [x] Upgrade spring boot, service-base and repo-core and make it compiling
  - [x] find a replacement for the elastic config
    - client has been replaced by: https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/getting-started-java.html
    - I think the support is based on repo-core or service-base, I should check/ask what the preconditions are on that side. Until now, it provided:
      - configuration class
      - exposure of the endpoint depending on a config switch
      - is it more in new versions?
- [x] builds
- [x] runs
- [x] tests run
  - [x] test which do not work anymore due to the change on the error message not being available now, but the body is.
  - [x] tests which return 404 instead of 200 when querying known pids
  - [x] tests testing swagger availability: returns 403 on access. Probably related to spring security filter chain.
  - [x] tests of elasticsearch run (disabled by default, require a local elastic instance)
    - `Caused by: java.net.UnknownHostException: http://localhost:9200: nodename nor servname provided, or not known` even though elastic was available at this address (tried elastic 7 and 8)
- [x] fix linting issues
- [x] test coverage – I can't see why it should have changed (claimed -0.3%). So I took the opportunity to test the handlediff class.

---

Breaking changes:

- It does now matter if `/api/v1/known-pids` (works) is queried or `/api/v1/known-pids/`. This is [due to a change in spring boot 3](https://www.baeldung.com/spring-boot-3-url-matching). I do not plan to work around this, as some options may be deprecated at some point anyway, and any other workaround will include a lot of boilerplate.