### PR TITLE
Fix 197 handle prefix missing slash

### DIFF
--- a/src/main/java/edu/kit/datamanager/pit/configuration/HandleCredentials.java
+++ b/src/main/java/edu/kit/datamanager/pit/configuration/HandleCredentials.java
@@ -45,9 +45,6 @@ public class HandleCredentials {
     @NotNull
     private Path privateKeyPath;
 
-    // We get the passphrase out of an environment variable
-    // instead of a path to a file containing the passphrase in a properties file.
-    // Optional, as key might be unencrypted.
     /**
      * The passphrase for the key file stored at privateKeyPath.
      * 

--- a/src/main/java/edu/kit/datamanager/pit/configuration/HandleCredentials.java
+++ b/src/main/java/edu/kit/datamanager/pit/configuration/HandleCredentials.java
@@ -67,6 +67,9 @@ public class HandleCredentials {
     }
 
     public String getHandleIdentifierPrefix() {
+        if (!this.handleIdentifierPrefix.endsWith("/")) {
+            this.handleIdentifierPrefix += "/";
+        }
         return handleIdentifierPrefix;
     }
 

--- a/src/main/java/edu/kit/datamanager/pit/configuration/HandleCredentials.java
+++ b/src/main/java/edu/kit/datamanager/pit/configuration/HandleCredentials.java
@@ -20,6 +20,8 @@ import edu.kit.datamanager.pit.common.InvalidConfigException;
 @Validated
 @Configuration
 public class HandleCredentials {
+    private static final String HANDLE_SEPARATOR = "/";
+
     /**
      * The handle PID of the user / account to create PIDs.
      */
@@ -64,8 +66,8 @@ public class HandleCredentials {
     }
 
     public String getHandleIdentifierPrefix() {
-        if (!this.handleIdentifierPrefix.endsWith("/")) {
-            this.handleIdentifierPrefix += "/";
+        if (!this.handleIdentifierPrefix.endsWith(HANDLE_SEPARATOR)) {
+            this.handleIdentifierPrefix += HANDLE_SEPARATOR;
         }
         return handleIdentifierPrefix;
     }

--- a/src/test/java/edu/kit/datamanager/pit/configuration/HandleCredentialsTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/configuration/HandleCredentialsTest.java
@@ -1,0 +1,28 @@
+package edu.kit.datamanager.pit.configuration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class HandleCredentialsTest {
+
+    final String noSlash = "withoutSlash";
+    final String withSlash = "withoutSlash/";
+
+    @Test
+    @DisplayName("Expect handle prefix has a slash, even if it was configured WITHOUT it.")
+    void testGetHandleIdentifierPrefixWithoutSlash() {
+        HandleCredentials creds = new HandleCredentials();
+        creds.setHandleIdentifierPrefix(noSlash);
+        assertEquals(withSlash, creds.getHandleIdentifierPrefix());
+    }
+
+    @Test
+    @DisplayName("Expect handle prefix has a slash, even if it was configured WITH it.")
+    void testGetHandleIdentifierPrefixWithSlash() {
+        HandleCredentials creds = new HandleCredentials();
+        creds.setHandleIdentifierPrefix(withSlash);
+        assertEquals(withSlash, creds.getHandleIdentifierPrefix());
+    }
+}


### PR DESCRIPTION
Fixes #197 

The idea is to give the responsibility to the configuration class, as it is specific to the provider anyway. A system with configurable prefix could use an extra attribute for this. The in-memory system for short-lived testing and the Database-based system for longer-living tests uses currently "sandboxed/" as prefix and does not have configuration (except for the database). So these are not affected. But if they would be made configurable, we'd have to remember to do it right in every place again (in possibly different ways, depending on the system).

I think this is a good and simple solution for the current situation.