### PR TITLE
fix: work around elastic api not working due to spring boot bug

### DIFF
--- a/config/application-default.properties
+++ b/config/application-default.properties
@@ -116,6 +116,10 @@ repo.search.url: http://localhost:9200
 #spring.elasticsearch.password=secret
 #spring.elasticsearch.socket-timeout=10s
 
+# Due to bug in spring cloud gateway
+# https://github.com/spring-cloud/spring-cloud-gateway/issues/3154
+spring.cloud.gateway.proxy.sensitive=content-length
+
 #################
 ### Messaging ###
 #################

--- a/config/application-docker.properties
+++ b/config/application-docker.properties
@@ -116,6 +116,10 @@ repo.search.url: http://localhost:9200
 #spring.elasticsearch.password=secret
 #spring.elasticsearch.socket-timeout=10s
 
+# Due to bug in spring cloud gateway
+# https://github.com/spring-cloud/spring-cloud-gateway/issues/3154
+spring.cloud.gateway.proxy.sensitive=content-length
+
 #################
 ### Messaging ###
 #################

--- a/src/test/resources/test/application-test.properties
+++ b/src/test/resources/test/application-test.properties
@@ -40,7 +40,7 @@ management.endpoints.web.exposure.include: *
 #logging.level.edu.kit.datamanager.doip:TRACE
 logging.level.edu.kit: DEBUG
 #logging.level.org.springframework.transaction: TRACE
-logging.level.org.springframework: WARN 
+logging.level.org.springframework: WARN
 logging.level.org.springframework.amqp: WARN
 logging.level.com.zaxxer.hikari: WARN
 
@@ -96,6 +96,10 @@ repo.search.enabled: false
 management.health.elasticsearch.enabled: false
 repo.search.url: http://localhost:9200
 repo.search.index: *
+
+# Due to bug in spring cloud gateway
+# https://github.com/spring-cloud/spring-cloud-gateway/issues/3154
+spring.cloud.gateway.proxy.sensitive=content-length
 
 ################
 ### Keycloak ###


### PR DESCRIPTION
Due to a bug in spring boot (documented in the change), we need to set a configuration property to work around the issue. This PR inserts the property into all relevant configuration files.