### PR TITLE
Implement dryrun parameter for PID updates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/src/main/java/edu/kit/datamanager/pit/web/ITypingRestResource.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/ITypingRestResource.java
@@ -107,8 +107,13 @@ public interface ITypingRestResource {
     public ResponseEntity<PIDRecord> createPID(
             @RequestBody
             final PIDRecord rec,
-            
-            @Parameter(description = "If true, only validation will be done and no PID will be created. No data will be changed and no services will be notified.", required = false)
+
+            @Parameter(
+                    description = "If true, only validation will be done" +
+                            " and no PID will be created. No data will be changed" +
+                            " and no services will be notified.",
+                    required = false
+            )
             @RequestParam(name = "dryrun", required = false, defaultValue = "false")
             boolean dryrun,
 
@@ -169,7 +174,14 @@ public interface ITypingRestResource {
             @RequestBody
             final PIDRecord rec,
 
-            @Parameter(description = "If true, only validation will be done and no PID will be updated. No data will be changed and no services will be notified.", required = false)
+            @Parameter(
+                    description = "If true, no PID will be updated. Only" +
+                            " validation checks are performed, and the expected" +
+                            " response, including the new eTag, will be returned." +
+                            " No data will be changed and no services will be" +
+                            " notified.",
+                    required = false
+            )
             @RequestParam(name = "dryrun", required = false, defaultValue = "false")
             boolean dryrun,
 
@@ -205,7 +217,12 @@ public interface ITypingRestResource {
         @ApiResponse(responseCode = "500", description = "Server error. See body for details.", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
     })
     public ResponseEntity<PIDRecord> getRecord (
-            @Parameter(description = "If true, validation will be run on the resolved PID. On failure, an error will be returned. On success, the PID will be resolved.", required = false)
+            @Parameter(
+                    description = "If true, validation will be run on the" +
+                            " resolved PID. On failure, an error will be" +
+                            " returned. On success, the PID will be resolved.",
+                    required = false
+            )
             @RequestParam(name = "validation", required = false, defaultValue = "false")
             boolean validation,
 

--- a/src/main/java/edu/kit/datamanager/pit/web/ITypingRestResource.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/ITypingRestResource.java
@@ -121,15 +121,16 @@ public interface ITypingRestResource {
      * Update the given PIDs record using the information provided in the request
      * body. The record is expected to contain the identifier of the matching
      * profile. Conditions for a valid record are the same as for creation.
-     * 
+     * <p>
      * Important note: Validation may take up to 30+ seconds. For details, see the
      * documentation of "POST /pid/".
      *
      * @param rec the PID record.
+     * @param dryrun if only validation shall be executed.
      *
      * @return the record (on success).
      *
-     * @throws IOException
+     * @throws IOException if the record could not be updated.
      */
     @PutMapping(
         path = "pid/**",
@@ -167,6 +168,10 @@ public interface ITypingRestResource {
     public ResponseEntity<PIDRecord> updatePID(
             @RequestBody
             final PIDRecord rec,
+
+            @Parameter(description = "If true, only validation will be done and no PID will be updated. No data will be changed and no services will be notified.", required = false)
+            @RequestParam(name = "dryrun", required = false, defaultValue = "false")
+            boolean dryrun,
 
             final WebRequest request,
             final HttpServletResponse response,

--- a/src/main/java/edu/kit/datamanager/pit/web/impl/TypingRESTResourceImpl.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/impl/TypingRESTResourceImpl.java
@@ -161,9 +161,12 @@ public class TypingRESTResourceImpl implements ITypingRestResource {
     @Override
     public ResponseEntity<PIDRecord> updatePID(
             PIDRecord pidRecord,
+            boolean dryrun,
+
             final WebRequest request,
             final HttpServletResponse response,
-            final UriComponentsBuilder uriBuilder) throws IOException {
+            final UriComponentsBuilder uriBuilder
+    ) throws IOException {
         // PID validation
         String pid = getContentPathFromRequest("pid", request);
         String pidInternal = pidRecord.getPid();
@@ -183,6 +186,11 @@ public class TypingRESTResourceImpl implements ITypingRestResource {
         // record validation
         pidRecord.setPid(pid);
         this.typingService.validate(pidRecord);
+
+        if (dryrun) {
+            // dryrun only does validation. Stop now and return as we would later on.
+            return ResponseEntity.ok().eTag(quotedEtag(pidRecord)).body(pidRecord);
+        }
 
         // update and send message
         if (this.typingService.updatePID(pidRecord)) {

--- a/src/main/java/edu/kit/datamanager/pit/web/impl/TypingRESTResourceImpl.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/impl/TypingRESTResourceImpl.java
@@ -170,7 +170,7 @@ public class TypingRESTResourceImpl implements ITypingRestResource {
         if (hasPid(pidRecord) && !pid.equals(pidInternal)) {
             throw new RecordValidationException(
                 pidRecord,
-                "PID in record was given, but it was not the same as the PID in the URL. Ignore request, assuming this was not intended.");
+                "Optional PID in record is given (%s), but it was not the same as the PID in the URL (%s). Ignore request, assuming this was not intended.".formatted(pidInternal, pid));
         }
         
         PIDRecord existingRecord = this.typingService.queryAllProperties(pid);

--- a/src/main/java/edu/kit/datamanager/pit/web/impl/TypingRESTResourceImpl.java
+++ b/src/main/java/edu/kit/datamanager/pit/web/impl/TypingRESTResourceImpl.java
@@ -180,12 +180,13 @@ public class TypingRESTResourceImpl implements ITypingRestResource {
         if (existingRecord == null) {
             throw new PidNotFoundException(pid);
         }
-        // throws exception (HTTP 412) if check fails.
-        ControllerUtils.checkEtag(request, existingRecord);
 
         // record validation
         pidRecord.setPid(pid);
         this.typingService.validate(pidRecord);
+
+        // throws exception (HTTP 412) if check fails.
+        ControllerUtils.checkEtag(request, existingRecord);
 
         if (dryrun) {
             // dryrun only does validation. Stop now and return as we would later on.

--- a/src/test/java/edu/kit/datamanager/pit/web/EtagTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/EtagTest.java
@@ -27,7 +27,12 @@ import edu.kit.datamanager.pit.domain.PIDRecord;
 
 @AutoConfigureMockMvc
 // JUnit5 + Spring
-@SpringBootTest
+@SpringBootTest(
+    properties = {
+            // assume validation will succeed, as we want to only test etag here
+            "pit.validation.strategy = none-debug",
+    }
+)
 @TestPropertySource("/test/application-test.properties")
 @ActiveProfiles("test")
 class EtagTest {

--- a/src/test/java/edu/kit/datamanager/pit/web/RestWithHandleProtocolTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/RestWithHandleProtocolTest.java
@@ -29,23 +29,18 @@ import jakarta.servlet.ServletContext;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-// Might be needed for WebApp testing according to
-// https://www.baeldung.com/integration-testing-in-spring
-// @WebAppConfiguration
-// Default preparation foo for mockMVC
+/**
+ * Testing with the handle protocol is currently read-only.
+ * This is due to the fact that we would need credentials for testing.
+ * We can test internal processes, though, for example using the dryrun APIs.
+ */
 @AutoConfigureMockMvc
-// JUnit5 + Spring
 @SpringBootTest(properties = {
     // Set the Handle Protocol implementation
     "pit.pidsystem.implementation = HANDLE_PROTOCOL"
 })
 @TestPropertySource("/test/application-test.properties")
 @ActiveProfiles("test")
-/**
- * Testing with the handle protocol is currently read-only.
- * This is due to the fact that we would need credentials for testing.
- * We can test internal processes, though, for example using the dryrun APIs.
- */
 class RestWithHandleProtocolTest {
 
     @Autowired
@@ -68,7 +63,7 @@ class RestWithHandleProtocolTest {
         assertNotNull(this.mockMvc);
         assertNotNull(this.webApplicationContext);
         ServletContext servletContext = webApplicationContext.getServletContext();
-        
+
         assertNotNull(servletContext);
         assertInstanceOf(MockServletContext.class, servletContext);
         assertNotNull(webApplicationContext.getBean(ITypingRestResource.class));
@@ -87,7 +82,7 @@ class RestWithHandleProtocolTest {
             .andDo(MockMvcResultHandlers.print())
             .andExpect(MockMvcResultMatchers.status().isOk())
             .andReturn();
-        
+
         String resolvedBody = resolved.getResponse().getContentAsString();
         PIDRecord resolvedRecord = mapper.readValue(resolvedBody, PIDRecord.class);
         assertEquals(pid, resolvedRecord.getPid());

--- a/src/test/java/edu/kit/datamanager/pit/web/RestWithHandleProtocolTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/RestWithHandleProtocolTest.java
@@ -1,5 +1,6 @@
 package edu.kit.datamanager.pit.web;
 
+import org.apache.http.entity.ContentType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
@@ -20,11 +21,9 @@ import edu.kit.datamanager.pit.domain.PIDRecord;
 import edu.kit.datamanager.pit.pidsystem.impl.HandleProtocolAdapter;
 import edu.kit.datamanager.pit.pidsystem.impl.InMemoryIdentifierSystem;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 
 import jakarta.servlet.ServletContext;
 
@@ -41,8 +40,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
     "pit.pidsystem.implementation = HANDLE_PROTOCOL"
 })
 @TestPropertySource("/test/application-test.properties")
-// TODO why a testing profile?
 @ActiveProfiles("test")
+/**
+ * Testing with the handle protocol is currently read-only.
+ * This is due to the fact that we would need credentials for testing.
+ * We can test internal processes, though, for example using the dryrun APIs.
+ */
 class RestWithHandleProtocolTest {
 
     @Autowired
@@ -67,7 +70,7 @@ class RestWithHandleProtocolTest {
         ServletContext servletContext = webApplicationContext.getServletContext();
         
         assertNotNull(servletContext);
-        assertTrue(servletContext instanceof MockServletContext);
+        assertInstanceOf(MockServletContext.class, servletContext);
         assertNotNull(webApplicationContext.getBean(ITypingRestResource.class));
         assertNotNull(webApplicationContext.getBean(HandleProtocolAdapter.class));
         assertThrows(NoSuchBeanDefinitionException.class, () -> {
@@ -88,5 +91,25 @@ class RestWithHandleProtocolTest {
         String resolvedBody = resolved.getResponse().getContentAsString();
         PIDRecord resolvedRecord = mapper.readValue(resolvedBody, PIDRecord.class);
         assertEquals(pid, resolvedRecord.getPid());
+    }
+
+    @Test
+    void testUpdateWithPidGiven() throws Exception {
+        String etag = this.mockMvc.perform(
+            get("/api/v1/pit/pid/21.11152/474a4b1c-de93-4d4a-b33d-1d32d63baf4b?validation=false")
+        )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(MockMvcResultMatchers.status().is2xxSuccessful())
+            .andReturn()
+                .getResponse()
+                .getHeader("ETag");
+        this.mockMvc.perform(
+            put("/api/v1/pit/pid/21.11152/474a4b1c-de93-4d4a-b33d-1d32d63baf4b?dryrun=true")
+                .content("{ \"pid\": \"21.11152/474a4b1c-de93-4d4a-b33d-1d32d63baf4b\", \"entries\": { \"21.T11148/076759916209e5d62bd5\": [ { \"key\": \"21.T11148/076759916209e5d62bd5\", \"name\": \"kernelInformationProfile\", \"value\": \"21.T11148/b9b76f887845e32d29f7\" } ], \"21.T11148/397d831aa3a9d18eb52c\": [ { \"key\": \"21.T11148/397d831aa3a9d18eb52c\", \"name\": \"dateModified\", \"value\": \"2024-10-14T07:16:46+00:00\" } ], \"21.T11148/82e2503c49209e987740\": [ { \"key\": \"21.T11148/82e2503c49209e987740\", \"name\": \"checksum\", \"value\": \"{ \\\"sha256sum\\\": \\\"a92ad3bd2b0856b70d3f98cb2fa21964ea7f91218c46e327b65a0937c50a885c\\\" }\" } ], \"21.T11148/aafd5fb4c7222e2d950a\": [ { \"key\": \"21.T11148/aafd5fb4c7222e2d950a\", \"name\": \"dateCreated\", \"value\": \"2024-10-14T07:16:46+00:00\" } ], \"21.T11148/b8457812905b83046284\": [ { \"key\": \"21.T11148/b8457812905b83046284\", \"name\": \"digitalObjectLocation\", \"value\": \"https://paint-database.org/WRI1030197/WRI1030197-catalog-stac.json\" } ], \"21.T11148/1a73af9e7ae00182733b\": [ { \"key\": \"21.T11148/1a73af9e7ae00182733b\", \"name\": \"contact\", \"value\": \"https://orcid.org/0009-0007-0235-4995\" }, { \"key\": \"21.T11148/1a73af9e7ae00182733b\", \"name\": \"contact\", \"value\": \"https://orcid.org/0000-0002-2233-1041\" }, { \"key\": \"21.T11148/1a73af9e7ae00182733b\", \"name\": \"contact\", \"value\": \"https://orcid.org/0000-0001-9648-4385\" }, { \"key\": \"21.T11148/1a73af9e7ae00182733b\", \"name\": \"contact\", \"value\": \"https://orcid.org/0000-0002-9197-1739\" }, { \"key\": \"21.T11148/1a73af9e7ae00182733b\", \"name\": \"contact\", \"value\": \"https://orcid.org/0000-0002-4705-6285\" } ], \"21.T11148/2f314c8fe5fb6a0063a8\": [ { \"key\": \"21.T11148/2f314c8fe5fb6a0063a8\", \"name\": \"licenseURL\", \"value\": \"https://cdla.dev/permissive-2-0/\" } ], \"21.T11148/1c699a5d1b4ad3ba4956\": [ { \"key\": \"21.T11148/1c699a5d1b4ad3ba4956\", \"name\": \"digitalResourceType\", \"value\": \"application/json\" } ] }}")
+                .contentType(ContentType.APPLICATION_JSON.getMimeType())
+                .header("If-Match", etag)
+        )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(MockMvcResultMatchers.status().is2xxSuccessful());
     }
 }

--- a/src/test/java/edu/kit/datamanager/pit/web/RestWithInMemoryTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/RestWithInMemoryTest.java
@@ -205,7 +205,7 @@ class RestWithInMemoryTest {
         // we store PIDs only if the PID was created successfully
         assertEquals(0, this.knownPidsDao.count());
         // assume error parsed from body
-        assertTrue(0 < result.getResponse().getContentAsString().length());
+        assertFalse(result.getResponse().getContentAsString().isEmpty());
     }
 
     @Test
@@ -235,6 +235,7 @@ class RestWithInMemoryTest {
         PIDRecord original = ApiMockUtils.registerSomeRecord(this.mockMvc);
         PIDRecord modified = ApiMockUtils.clone(original);
         modified.getEntries().get("21.T11148/b8457812905b83046284").get(0).setValue("https://example.com/anotherUrlAsBefore");
+        assertNotEquals(original, modified);
         PIDRecord updatedRecord = ApiMockUtils.updateRecord(this.mockMvc, original, modified);
         assertEquals(modified, updatedRecord);
     }

--- a/src/test/java/edu/kit/datamanager/pit/web/RestWithLocalPidSystemTest.java
+++ b/src/test/java/edu/kit/datamanager/pit/web/RestWithLocalPidSystemTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 
 import jakarta.servlet.ServletContext;
 
@@ -46,10 +47,6 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.head;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -201,6 +198,7 @@ class RestWithLocalPidSystemTest {
         PIDRecord original = ApiMockUtils.registerSomeRecord(this.mockMvc);
         PIDRecord modified = ApiMockUtils.clone(original);
         modified.getEntries().get("21.T11148/b8457812905b83046284").get(0).setValue("https://example.com/anotherUrlAsBefore");
+        assertNotEquals(original, modified);
         PIDRecord updatedRecord = ApiMockUtils.updateRecord(this.mockMvc, original, modified);
         assertEquals(modified, updatedRecord);
     }


### PR DESCRIPTION
Motivated by #243, as it tests precisely this case. This PR was **not** able to reproduce the issue!

This implements dryrun for the update API. This means:

- It will require a valid record, including matching PIDs in URL and record (although the record PID can be omitted, as before).
- It will require a valid etag of the previous version
- The PID needs to exist
- The new etag will be returned
- Nothing really changes
  - The PID record will not be modified
  - No AMQP message will be sent
  - No elastic index will be updated, etc

How does it differ from the create-dryrun? Mainly in that it has the properties of an update:

- The PID needs to exist in beforehand (opposite to create)
- Etag is required
- New etag will be returned

Why do we need this?

- Consistency: It seems this is kind of expected by users.
- Testing: It allows to at least partially test the handle protocol with create/update, although it does currently not really increase the test coverage. This may change over time as we plan to package all functionality which does not need authentication into other classes, which then may be executed in tests.

Other noteworthy changes:

- improved logging on update if PIDs do not match, to have a more comprehensible source of information in such error reports
- added an update test using dryrun using the read-only handle protocol tests

Breaking changes:

- none expected