### PR TITLE
Permit configuration of actuators

### DIFF
--- a/config/application-default.properties
+++ b/config/application-default.properties
@@ -44,7 +44,7 @@ spring.servlet.multipart.max-request-size: 100MB
 management.endpoint.health.access: unrestricted
 management.endpoint.health.show-details: ALWAYS
 management.endpoint.health.sensitive: false
-management.endpoints.web.exposure.include: *
+management.endpoints.web.exposure.include: health, info
 
 ###############
 ### Logging ###
@@ -106,6 +106,7 @@ spring.autoconfigure.exclude=org.keycloak.adapters.springboot.KeycloakAutoConfig
 # enables search endpoint at /api/v1/search
 repo.search.enabled: false
 repo.search.index: *
+# only enable if endpoint is enabled:
 management.health.elasticsearch.enabled: false
 
 # TO BE REMOVED!
@@ -132,6 +133,8 @@ spring.cloud.gateway.proxy.sensitive=content-length
 # exchange aka. topic and the queue. The routingKeys are defining wich messages are 
 # routed to the aforementioned queue.
 repo.messaging.enabled: false
+# enables report via health actuator. Only activate if messaging is enabled.
+management.health.rabbit.enabled: false
 repo.messaging.hostname: localhost
 repo.messaging.port: 5672
 repo.messaging.sender.exchange: record_events

--- a/config/application-docker.properties
+++ b/config/application-docker.properties
@@ -44,7 +44,7 @@ spring.servlet.multipart.max-request-size: 100MB
 management.endpoint.health.enabled: true
 management.endpoint.health.show-details: ALWAYS
 management.endpoint.health.sensitive: false
-management.endpoints.web.exposure.include: *
+management.endpoints.web.exposure.include: health, info
 
 ###############
 ### Logging ###
@@ -106,6 +106,7 @@ spring.autoconfigure.exclude=org.keycloak.adapters.springboot.KeycloakAutoConfig
 # enables search endpoint at /api/v1/search
 repo.search.enabled: false
 repo.search.index: *
+# only enable if endpoint is enabled:
 management.health.elasticsearch.enabled: false
 
 # TO BE REMOVED!
@@ -132,6 +133,8 @@ spring.cloud.gateway.proxy.sensitive=content-length
 # exchange aka. topic and the queue. The routingKeys are defining wich messages are 
 # routed to the aforementioned queue.
 repo.messaging.enabled: false
+# enables report via health actuator. Only activate if messaging is enabled.
+management.health.rabbit.enabled: false
 repo.messaging.hostname: localhost
 repo.messaging.port: 5672
 repo.messaging.sender.exchange: record_events

--- a/src/main/java/edu/kit/datamanager/pit/configuration/WebSecurityConfig.java
+++ b/src/main/java/edu/kit/datamanager/pit/configuration/WebSecurityConfig.java
@@ -77,6 +77,8 @@ public class WebSecurityConfig {
           .requestMatchers(HttpMethod.GET, "/swagger-ui.html").permitAll()
           .requestMatchers(HttpMethod.GET, "/swagger-ui/**").permitAll()
           .requestMatchers(HttpMethod.GET, "/v3/**").permitAll()
+          // permit access to actuator endpoints
+          .requestMatchers("/actuator/**").permitAll()
           // only the actual API is protected
           .requestMatchers("/api/v1/**").authenticated()
       )


### PR DESCRIPTION
Spring provides a default setting and various options to expose actuators in different ways. We now permit access to actuators, so these settings actually do work.

We also provide a slightly different default, which not only exposes health (spring default), but also info, which contains version and git information. Of course, this can be changed by the user.

This is not a breaking change, as the settings did not have any effect in beforehand, due to the spring security configuration class.