### PR TITLE
Fix: get all PIDs of prefix

### DIFF
--- a/src/main/java/edu/kit/datamanager/pit/pidsystem/impl/HandleProtocolAdapter.java
+++ b/src/main/java/edu/kit/datamanager/pit/pidsystem/impl/HandleProtocolAdapter.java
@@ -378,21 +378,21 @@ public class HandleProtocolAdapter implements IIdentifierSystem {
 
         HandleResolver resolver = new HandleResolver();
         SiteInfo site;
+        String prefix = handleCredentials.getHandleIdentifierPrefix().replace("/", "");
         {
             HandleValue[] prefixValues;
             try {
-                prefixValues = resolver.resolveHandle(handleCredentials.getHandleIdentifierPrefix());
+                prefixValues = resolver.resolveHandle(prefix);
                 site = BatchUtil.getFirstPrimarySiteFromHserv(prefixValues, resolver);
             } catch (HandleException e) {
-                throw new ExternalServiceException(SERVICE_NAME_HANDLE, e);
+                throw new ExternalServiceException(SERVICE_NAME_HANDLE, "Tried resolving " + prefix, e);
             }
         }
 
-        String prefix = handleCredentials.getHandleIdentifierPrefix();
         try {
             return BatchUtil.listHandles(prefix, site, resolver, auth);
         } catch (HandleException e) {
-            throw new ExternalServiceException(SERVICE_NAME_HANDLE, e);
+            throw new ExternalServiceException(SERVICE_NAME_HANDLE, "Tried resolving " + prefix, e);
         }
     }
 


### PR DESCRIPTION
Writing all PIDs to a CSV file was not working since the prefix in the meanwhile always includes a slash at the end, which needs to be removed in this special case.

- [x] fixed issue
- [x] improved error messages
- [x] tested locally